### PR TITLE
Implement Forwarding

### DIFF
--- a/Examples/Universal_Gateway/Universal_Gateway.ino
+++ b/Examples/Universal_Gateway/Universal_Gateway.ino
@@ -126,7 +126,15 @@ void loop() {
 #endif
 
 #if defined(ESP_SEND)
+#ifdef ESPNOW_ALL
   ESPNow.release();
+#endif
+#ifdef ESPNOW_PEER_1
+  ESPNow.release(ESPNOW1);
+#endif
+#ifdef ESPNOW_PEER_2
+  ESPNow.release(ESPNOW2);
+#endif
 #endif
 
 #if defined(MQTT_SEND)

--- a/Examples/Universal_Gateway/fdrs_config.h
+++ b/Examples/Universal_Gateway/fdrs_config.h
@@ -29,6 +29,7 @@
 #define LORA_PEER_1    0x0E  // LoRa1 Address
 #define LORA_PEER_2    0x0F  // LoRa2 Address
 
+#define ESPNOW_ALL           //send to all know and unknow peers
 #define ESPNOW_PEER_1  0x0C  // ESPNOW1 Address 
 #define ESPNOW_PEER_2  0x0D  // ESPNOW2 Address
 

--- a/fdrs_gateway.h
+++ b/fdrs_gateway.h
@@ -39,13 +39,18 @@ public:
 
     static void add_data(DataReading_t *data);
 
-    void release(void);
+    void release(uint8_t *peer_mac = NULL);
+
     void flush(void);
+
+protected:
+    std::vector<DataReading_t> *get_data();
 
 private:
     static uint32_t peer_id;
     static std::vector<DataReading_t> _data;
     virtual void send(std::vector<DataReading_t> data) = 0;
+    virtual void forward(uint8_t *peer_mac ,std::vector<DataReading_t> data) = 0;
 };
 
 class ESP_FDRSGateWay: public FDRSGateWayBase{
@@ -69,6 +74,7 @@ private:
     static void setup(void);
 
     void send(std::vector<DataReading_t> data) override;
+    void forward(uint8_t *peer_mac ,std::vector<DataReading_t> data) override;
 
     void list_peer(uint8_t peer_mac[6]);
     void unlist_peer(uint8_t peer_mac[6]);
@@ -101,6 +107,7 @@ private:
 
     void reconnect();
     void send(std::vector<DataReading_t> data) override;
+    void forward(uint8_t *peer_mac ,std::vector<DataReading_t> data) override;
 
 };
 
@@ -122,6 +129,7 @@ private:
     static void setup(void);
     void pull(void);
     void send(std::vector<DataReading_t> data) override;
+    void forward(uint8_t *peer_mac ,std::vector<DataReading_t> data) override;
 
 };
 
@@ -152,8 +160,8 @@ private:
 
     void transmit(DataReading_t *packet, uint8_t len);
 
-
     void send(std::vector<DataReading_t> data) override;
+    void forward(uint8_t *peer_mac ,std::vector<DataReading_t> data) override;
 
 };
 


### PR DESCRIPTION
Implement forwarding to a specific peer.

The `release` function now takes a parameter that is the peer_mac. This is the data destination. The `release` function will then send all collected data to that peer.

The default parameter of the release function is NULL. If no parameter is pass to the `release` function then it will broadcast to all peers including unknow ones that have sent to that particular node.
Note: All unknown peers are erased after sending in a "send to all" release.

This can be configure with the macros in the Universal Gateway example fdrs_config.h.
```
#define ESPNOW_ALL           //send to all know and unknow peers
#define ESPNOW_PEER_1  0x0C  // ESPNOW1 Address 
#define ESPNOW_PEER_2  0x0D  // ESPNOW2 Address
```
This block in the example determines how data is sent.
```
#if defined(ESP_SEND)
#ifdef ESPNOW_ALL
  ESPNow.release();
#endif
#ifdef ESPNOW_PEER_1
  ESPNow.release(ESPNOW1);
#endif
#ifdef ESPNOW_PEER_2
  ESPNow.release(ESPNOW2);
#endif
#endif 
```

This is only for the ESPNOW protocol as per https://github.com/timmbogner/Farm-Data-Relay-System/pull/20

We can have a look at LoRa once we have the ESP working.

Any questions feel free to ask.