### PR TITLE
Fixed junk memory in peerInfo. Add debug macro.

### DIFF
--- a/fdrs_gateway.cpp
+++ b/fdrs_gateway.cpp
@@ -109,6 +109,7 @@ void ESP_FDRSGateWay::init(uint8_t inturnal_mac[5]){
 
 #if defined(ESP32)
     esp_now_peer_info_t peerInfo;
+    memset(&peerInfo, 0, sizeof(peerInfo));
     peerInfo.channel = 0;
     peerInfo.encrypt = false;
     // Register first peer
@@ -199,6 +200,7 @@ void ESP_FDRSGateWay::list_peer(uint8_t peer_mac[6]){
 
 #if defined(ESP32)
     esp_now_peer_info_t peerInfo;
+    memset(&peerInfo, 0, sizeof(peerInfo));
     peerInfo.channel = 0;
     peerInfo.encrypt = false;
     memcpy(peerInfo.peer_addr, peer_mac, 6);

--- a/fdrs_gateway.h
+++ b/fdrs_gateway.h
@@ -25,6 +25,8 @@
 
 #define USE_LORA
 
+#define DEBUG
+
 #ifdef DEBUG
 #define DBG(a) (Serial.println(a))
 #else


### PR DESCRIPTION
Suggest pulling my fork and testing before merging. It will make it easier for me to do updates and reduce your house keeping.

Added a debug macro to `fdrs_gateway.h`. Comment in or out as needed.

Fixed junk values getting placed in `peerInfo`.

ref: https://www.esp32.com/viewtopic.php?t=19858