### PR TITLE
Lora band and fs from GLOBALS were ignored

### DIFF
--- a/Universal_Sensor_beta/Universal_Sensor_beta.ino
+++ b/Universal_Sensor_beta/Universal_Sensor_beta.ino
@@ -8,10 +8,10 @@
 //
 
 
-#include "fdrs_sensor.h"
 #include "sensor_setup.h"
+#include "fdrs_sensor.h"
 
-FDRSLoRa FDRS(GTWY_MAC,READING_ID,MISO,MOSI,SCK,SS,RST,DIO0,BAND,SF);
+FDRSLoRa FDRS(GTWY_MAC,READING_ID,MISO,MOSI,SCK,SS,RST,DIO0,FDRS_BAND,FDRS_SF);
 
 float data1;
 float data2;


### PR DESCRIPTION
Fixed it by changing the order of the includes (as one references the other) and using FDRS_BAND and FDRS_SF in the constructor of the FDRSLora class.
See issue #33 for further explaination. 