### PR TITLE
Debug Error on Initializing LoRa before going into infinite while loop

### DIFF
--- a/Examples/1_LoRa_Sensor/fdrs_sensor.h
+++ b/Examples/1_LoRa_Sensor/fdrs_sensor.h
@@ -121,6 +121,7 @@ void beginFDRS() {
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/Examples/2_ESPNOW_Sensor/fdrs_sensor.h
+++ b/Examples/2_ESPNOW_Sensor/fdrs_sensor.h
@@ -121,6 +121,7 @@ void beginFDRS() {
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -121,6 +121,7 @@ void beginFDRS() {
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/Sensors/AHT20_fdrs/fdrs_sensor.h
+++ b/Sensors/AHT20_fdrs/fdrs_sensor.h
@@ -116,11 +116,12 @@ void beginFDRS() {
   DBG("Initializing LoRa!");
   DBG(BAND);
   DBG(SF);
-#ifndef __AVR__
+#ifdef ESP32
   SPI.begin(SCK, MISO, MOSI, SS);
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/Sensors/BME280_fdrs/fdrs_sensor.h
+++ b/Sensors/BME280_fdrs/fdrs_sensor.h
@@ -116,11 +116,12 @@ void beginFDRS() {
   DBG("Initializing LoRa!");
   DBG(BAND);
   DBG(SF);
-#ifndef __AVR__
+#ifdef ESP32
   SPI.begin(SCK, MISO, MOSI, SS);
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/Sensors/BMP280_fdrs/fdrs_sensor.h
+++ b/Sensors/BMP280_fdrs/fdrs_sensor.h
@@ -116,11 +116,12 @@ void beginFDRS() {
   DBG("Initializing LoRa!");
   DBG(BAND);
   DBG(SF);
-#ifndef __AVR__
+#ifdef ESP32
   SPI.begin(SCK, MISO, MOSI, SS);
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/Sensors/DHT22_fdrs/fdrs_sensor.h
+++ b/Sensors/DHT22_fdrs/fdrs_sensor.h
@@ -116,11 +116,12 @@ void beginFDRS() {
   DBG("Initializing LoRa!");
   DBG(BAND);
   DBG(SF);
-#ifndef __AVR__
+#ifdef ESP32
   SPI.begin(SCK, MISO, MOSI, SS);
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/Sensors/DS18B20_fdrs/fdrs_sensor.h
+++ b/Sensors/DS18B20_fdrs/fdrs_sensor.h
@@ -116,11 +116,12 @@ void beginFDRS() {
   DBG("Initializing LoRa!");
   DBG(BAND);
   DBG(SF);
-#ifndef __AVR__
+#ifdef ESP32
   SPI.begin(SCK, MISO, MOSI, SS);
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/Sensors/LilyGo_HiGrow_32/fdrs_sensor.h
+++ b/Sensors/LilyGo_HiGrow_32/fdrs_sensor.h
@@ -116,11 +116,12 @@ void beginFDRS() {
   DBG("Initializing LoRa!");
   DBG(BAND);
   DBG(SF);
-#ifndef __AVR__
+#ifdef ESP32
   SPI.begin(SCK, MISO, MOSI, SS);
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/Sensors/MESB_fdrs/fdrs_sensor.h
+++ b/Sensors/MESB_fdrs/fdrs_sensor.h
@@ -116,11 +116,12 @@ void beginFDRS() {
   DBG("Initializing LoRa!");
   DBG(BAND);
   DBG(SF);
-#ifndef __AVR__
+#ifdef ESP32
   SPI.begin(SCK, MISO, MOSI, SS);
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);

--- a/Sensors/TippingBucket/fdrs_sensor.h
+++ b/Sensors/TippingBucket/fdrs_sensor.h
@@ -116,11 +116,12 @@ void beginFDRS() {
   DBG("Initializing LoRa!");
   DBG(BAND);
   DBG(SF);
-#ifndef __AVR__
+#ifdef ESP32
   SPI.begin(SCK, MISO, MOSI, SS);
 #endif
   LoRa.setPins(SS, RST, DIO0);
   if (!LoRa.begin(FDRS_BAND)) {
+    DBG("Unable to initialize LoRa!");
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);


### PR DESCRIPTION
In my test setup I once connected the LoRa Board to the wrong pins. This resulted in `LoRa.begin(FDRS_BAND)` returning `0` which led the execution into the infinite while loop:

`if (!LoRa.begin(FDRS_BAND)) {
    while (1);
  }`

I don't know if this is intetnional, but the ESP8266 seems to not like that and it resets wit an error message.
Upon debugging with the ESP Exception decoder it crashes on that `while` line.

So to prevent from users having to go down that rabbit hole wondering why the ESP keeps resetting I suggest Sending a debug message first.

(Also included in this PR updating the addition of the SPI fix to the files that havent been updated)