### PR TITLE
Making FDRS datatypes globally available

### DIFF
--- a/Examples/1_LoRa_Sensor/fdrs_sensor.h
+++ b/Examples/1_LoRa_Sensor/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Examples/2_ESPNOW_Sensor/fdrs_sensor.h
+++ b/Examples/2_ESPNOW_Sensor/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/FDRS_Install/FDRS_datatypes.h
+++ b/FDRS_Install/FDRS_datatypes.h
@@ -1,0 +1,33 @@
+// A list of all datatypes you can use within FDRS.
+// If you are missing any data type, please open an issue at:
+// https://github.com/timmbogner/Farm-Data-Relay-System/issues
+ 
+#ifndef FDRS_DATA_TYPES
+#define FDRS_DATA_TYPES
+
+#define STATUS_T        0  // Status 
+#define TEMP_T          1  // Temperature 
+#define TEMP2_T         2  // Temperature #2
+#define HUMIDITY_T      3  // Relative Humidity 
+#define PRESSURE_T      4  // Atmospheric Pressure 
+#define LIGHT_T         5  // Light (lux) 
+#define SOIL_T          6  // Soil Moisture 
+#define SOIL2_T         7  // Soil Moisture #2 
+#define SOILR_T         8 // Soil Resistance 
+#define SOILR2_T        9 // Soil Resistance #2 
+#define OXYGEN_T        10 // Oxygen 
+#define CO2_T           11 // Carbon Dioxide
+#define WINDSPD_T       12 // Wind Speed
+#define WINDHDG_T       13 // Wind Direction
+#define RAINFALL_T      14 // Rainfall
+#define MOTION_T        15 // Motion
+#define VOLTAGE_T       16 // Voltage
+#define VOLTAGE2_T      17 // Voltage #2
+#define CURRENT_T       18 // Current
+#define CURRENT2_T      19 // Current #2
+#define IT_T            20 // Iterations
+#define LATITUDE_T      21 // GPS Latitude
+#define LONGITUDE_T     22 // GPS Longitude
+#define ALTITUDE_T      23 // GPS Altitude
+
+#endif

--- a/FDRS_Sensor/README.md
+++ b/FDRS_Sensor/README.md
@@ -31,27 +31,30 @@ IF defined, power control will bring a GPIO pin high within beginFDRS(). This is
 ## Type Definitions 
 For the moment, my thought is to reserve the first two bits of the type. I might use them in the future to indicate the data size or type (bool, char,  int, float, etc?). This leaves us with 64 possible type definitions. If you have more types to add, please get in touch!
 ```
-#define STATUS_T    0  // Status 
-#define TEMP_T      1  // Temperature 
-#define TEMP2_T     2  // Temperature #2
-#define HUMIDITY_T  3  // Relative Humidity 
-#define PRESSURE_T  4  // Atmospheric Pressure 
-#define LIGHT_T     5  // Light (lux) 
-#define SOIL_T      6  // Soil Moisture 
-#define SOIL2_T     7  // Soil Moisture #2 
-#define SOILR_T      8 // Soil Resistance 
-#define SOILR2_T     9 // Soil Resistance #2 
-#define OXYGEN_T    10 // Oxygen 
-#define CO2_T       11 // Carbon Dioxide
-#define WINDSPD_T   12 // Wind Speed
-#define WINDHDG_T   13 // Wind Direction
-#define RAINFALL_T  14 // Rainfall
-#define MOTION_T    15 // Motion
-#define VOLTAGE_T   16 // Voltage
-#define VOLTAGE2_T  17 // Voltage #2
-#define CURRENT_T   18 // Current
-#define CURRENT2_T  19 // Current #2
-#define IT_T        20 // Iterations
+#define STATUS_T        0  // Status 
+#define TEMP_T          1  // Temperature 
+#define TEMP2_T         2  // Temperature #2
+#define HUMIDITY_T      3  // Relative Humidity 
+#define PRESSURE_T      4  // Atmospheric Pressure 
+#define LIGHT_T         5  // Light (lux) 
+#define SOIL_T          6  // Soil Moisture 
+#define SOIL2_T         7  // Soil Moisture #2 
+#define SOILR_T         8 // Soil Resistance 
+#define SOILR2_T        9 // Soil Resistance #2 
+#define OXYGEN_T        10 // Oxygen 
+#define CO2_T           11 // Carbon Dioxide
+#define WINDSPD_T       12 // Wind Speed
+#define WINDHDG_T       13 // Wind Direction
+#define RAINFALL_T      14 // Rainfall
+#define MOTION_T        15 // Motion
+#define VOLTAGE_T       16 // Voltage
+#define VOLTAGE2_T      17 // Voltage #2
+#define CURRENT_T       18 // Current
+#define CURRENT2_T      19 // Current #2
+#define IT_T            20 // Iterations
+#define LATITUDE_T      21 // GPS Latitude
+#define LONGITUDE_T     22 // GPS Longitude
+#define ALTITUDE_T      23 // GPS Altitude
 ```
 ## Under the hood
 ```

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Sensors/AHT20_fdrs/fdrs_sensor.h
+++ b/Sensors/AHT20_fdrs/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Sensors/BME280_fdrs/fdrs_sensor.h
+++ b/Sensors/BME280_fdrs/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Sensors/BMP280_fdrs/fdrs_sensor.h
+++ b/Sensors/BMP280_fdrs/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Sensors/DHT22_fdrs/fdrs_sensor.h
+++ b/Sensors/DHT22_fdrs/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Sensors/DS18B20_fdrs/fdrs_sensor.h
+++ b/Sensors/DS18B20_fdrs/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Sensors/GenericGPS_fdrs/fdrs_sensor.h
+++ b/Sensors/GenericGPS_fdrs/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Sensors/LilyGo_HiGrow_32/fdrs_sensor.h
+++ b/Sensors/LilyGo_HiGrow_32/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Sensors/MESB_fdrs/fdrs_sensor.h
+++ b/Sensors/MESB_fdrs/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Sensors/TippingBucket/fdrs_sensor.h
+++ b/Sensors/TippingBucket/fdrs_sensor.h
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //
 #include "sensor_setup.h"
+#include <FDRS_datatypes.h>
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
 #include <espnow.h>
@@ -30,31 +31,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T        0  // Status 
-#define TEMP_T          1  // Temperature 
-#define TEMP2_T         2  // Temperature #2
-#define HUMIDITY_T      3  // Relative Humidity 
-#define PRESSURE_T      4  // Atmospheric Pressure 
-#define LIGHT_T         5  // Light (lux) 
-#define SOIL_T          6  // Soil Moisture 
-#define SOIL2_T         7  // Soil Moisture #2 
-#define SOILR_T         8 // Soil Resistance 
-#define SOILR2_T        9 // Soil Resistance #2 
-#define OXYGEN_T        10 // Oxygen 
-#define CO2_T           11 // Carbon Dioxide
-#define WINDSPD_T       12 // Wind Speed
-#define WINDHDG_T       13 // Wind Direction
-#define RAINFALL_T      14 // Rainfall
-#define MOTION_T        15 // Motion
-#define VOLTAGE_T       16 // Voltage
-#define VOLTAGE2_T      17 // Voltage #2
-#define CURRENT_T       18 // Current
-#define CURRENT2_T      19 // Current #2
-#define IT_T            20 // Iterations
-#define LATITUDE_T      21 // GPS Latitude
-#define LONGITUDE_T     22 // GPS Longitude
-#define ALTITUDE_T      23 // GPS Altitude
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/Universal_Sensor_beta/fdrs_sensor.h
+++ b/Universal_Sensor_beta/fdrs_sensor.h
@@ -10,6 +10,7 @@
 #define __FDRS_SENSOR__H__
 
 #include "fdrs_types.h"
+#include <FDRS_datatypes.h>
 
 //1 to enable debugging prints. 0 disables the debugging prints
 #define ENABLE_DEBUG 1 
@@ -48,28 +49,6 @@
 #else
 #define DBG(a)
 #endif
-
-#define STATUS_T    0  // Status 
-#define TEMP_T      1  // Temperature 
-#define TEMP2_T     2  // Temperature #2
-#define HUMIDITY_T  3  // Relative Humidity 
-#define PRESSURE_T  4  // Atmospheric Pressure 
-#define LIGHT_T     5  // Light (lux) 
-#define SOIL_T      6  // Soil Moisture 
-#define SOIL2_T     7  // Soil Moisture #2 
-#define SOILR_T      8 // Soil Resistance 
-#define SOILR2_T     9 // Soil Resistance #2 
-#define OXYGEN_T    10 // Oxygen 
-#define CO2_T       11 // Carbon Dioxide
-#define WINDSPD_T   12 // Wind Speed
-#define WINDHDG_T   13 // Wind Direction
-#define RAINFALL_T  14 // Rainfall
-#define MOTION_T    15 // Motion
-#define VOLTAGE_T   16 // Voltage
-#define VOLTAGE2_T  17 // Voltage #2
-#define CURRENT_T   18 // Current
-#define CURRENT2_T  19 // Current #2
-#define IT_T        20 // Iterations
 
 extern const uint8_t prefix[5];
 


### PR DESCRIPTION
As discussed in #35 I moved the definitions of data types to the FDRS_install folder, thus making them globally available and reducing redundance in the code.