### PR TITLE
Dev: refactoring GLOBALS to FDRS_GLOBALS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-fdrs_globals.h
 
+fdrs_globals.h

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+fdrs_globals.h
 

--- a/FDRS_Gateway/fdrs_functions.h
+++ b/FDRS_Gateway/fdrs_functions.h
@@ -16,7 +16,7 @@
 #define UART_IF Serial
 #endif
 
-#ifdef GLOBALS
+#ifdef FDRS_GLOBALS
 #define FDRS_WIFI_SSID GLOBAL_SSID
 #define FDRS_WIFI_PASS GLOBAL_PASS
 #define FDRS_MQTT_ADDR GLOBAL_MQTT_ADDR

--- a/examples/Universal_Sensor_beta/fdrs_sensor.h
+++ b/examples/Universal_Sensor_beta/fdrs_sensor.h
@@ -36,7 +36,7 @@
 #include "LoRa.h"
 #endif
 
-#ifdef GLOBALS
+#ifdef FDRS_GLOBALS
 #define FDRS_BAND GLOBAL_BAND
 #define FDRS_SF GLOBAL_SF
 #else

--- a/fdrs_functions.h
+++ b/fdrs_functions.h
@@ -16,7 +16,7 @@
 #define UART_IF Serial
 #endif
 
-#ifdef GLOBALS
+#ifdef FDRS_GLOBALS
 #define FDRS_WIFI_SSID GLOBAL_SSID
 #define FDRS_WIFI_PASS GLOBAL_PASS
 #define FDRS_MQTT_ADDR GLOBAL_MQTT_ADDR

--- a/fdrs_globals.h
+++ b/fdrs_globals.h
@@ -1,6 +1,5 @@
-// ToDo: refactor the global GLOBALS to FDRS_GLOBALS as GLOBALS is ... well, too global ;)
-#ifndef GLOBALS
-#define GLOBALS
+#ifndef FDRS_GLOBALS
+#define FDRS_GLOBALS
 #define GLOBAL_SSID "Your SSID"
 #define GLOBAL_PASS "Password"
 #define GLOBAL_MQTT_ADDR "192.168.0.8"
@@ -12,4 +11,4 @@
 #define GLOBAL_BAND 915E6 //LoRa Frequency Band
 #define GLOBAL_SF 7  //LoRa Spreading Factor
 
-#endif GLOBALS
+#endif FDRS_GLOBALS

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -17,7 +17,7 @@
 #include <LoRa.h>
 #endif
 
-#ifdef GLOBALS
+#ifdef FDRS_GLOBALS
 #define FDRS_BAND GLOBAL_BAND
 #define FDRS_SF GLOBAL_SF
 #else

--- a/keywords.txt
+++ b/keywords.txt
@@ -5,25 +5,41 @@
 ##########################################################
 # Datatypes and Class names (KEYWORD1)
 ##########################################################
-
 DataReading	KEYWORD1
+
 
 ##########################################################
 # Methods and Functions (KEYWORD2)
 ##########################################################
-
-beginFDRS	KEYWORD2
-loadFDRS	KEYWORD2
-sendFDRS	KEYWORD2
-sleepFDRS	KEYWORD2
 DBG	KEYWORD2
-getLoRa	KEYWORD2
-sendESPNOW	KEYWORD2
-sendSerial	KEYWORD2
-sendMQTT	KEYWORD2
+beginFDRS	KEYWORD2
 bufferESPNOW	KEYWORD2
-bufferSerial	KEYWORD2
-bufferMQTT	KEYWORD2
 bufferLoRa	KEYWORD2
-transmitLoRa	KEYWORD2
+bufferMQTT	KEYWORD2
+bufferSerial	KEYWORD2
+getLoRa	KEYWORD2
 getSerial	KEYWORD2
+loadFDRS	KEYWORD2
+sendESPNOW	KEYWORD2
+sendFDRS	KEYWORD2
+sendMQTT	KEYWORD2
+sendSerial	KEYWORD2
+sleepFDRS	KEYWORD2
+transmitLoRa	KEYWORD2
+
+
+##########################################################
+# Literals (LITERAL1)
+##########################################################
+DEBUG	LITERAL1
+DEBUG	LITERAL1
+DEEP_SLEEP	LITERAL1
+FDRS_BAND	LITERAL1
+FDRS_GLOBALS	LITERAL1
+FDRS_SF	LITERAL1
+//GTWY_MAC	LITERAL1
+MAC_PREFIX	LITERAL1
+POWER_CTRL	LITERAL1
+READING_ID	LITERAL1
+UNIT_MAC	LITERAL1
+USE_LORA	LITERAL1


### PR DESCRIPTION
- Refactored GLOBALS to FDRS_GLOBALS, as defining a global GLOBALS is too global. ;)
- added fdrs_globals.h to the .gitignore file as this may contain private data.

By adding FDRS_ as prefix to global definitions there is less probability for conflicts with other libraries.
#47 points into the same direction. 
