### PR TITLE
DEV: Refactored DEBUG and DBG to FDRS_DEBUG and FDRS_DBG

### DIFF
--- a/FDRS_Gateway/README.md
+++ b/FDRS_Gateway/README.md
@@ -16,7 +16,7 @@ In this example, the gateway is set to take any ESP-NOW packet it receives and s
 ## Options
 ### ```#define UNIT_MAC (0xNN)```
 The UNIT_MAC is the ESP-NOW and LoRa address of the gateway. This is the address that nodes or other gateways will use to pass data to this device.
-### ```#define DEBUG```
+### ```#define FDRS_DEBUG```
 This definition enables debug messages to be sent over the serial port. If disabled, the USB serial port is still used to echo data being sent via the sendSerial() command.
 ### ```#define RXD2 (pin)``` and ```TXD2 (pin)```
 These are the pins for inter-device serial communication. The single ESP8266 serial interface is not configurable, and thus these options only apply to ESP32 boards. 

--- a/FDRS_Gateway/fdrs_config.h
+++ b/FDRS_Gateway/fdrs_config.h
@@ -3,7 +3,7 @@
 //  GATEWAY 2.000 Configuration
 
 //#include <fdrs_globals.h> //Uncomment if you install the globals file
-#define DEBUG     //Enable USB-Serial debugging
+#define FDRS_DEBUG     //Enable USB-Serial debugging
 
 #define UNIT_MAC     0x01  // The address of this gateway
 

--- a/FDRS_Gateway/fdrs_functions.h
+++ b/FDRS_Gateway/fdrs_functions.h
@@ -4,7 +4,7 @@
 //  This is the 'meat and potatoes' of FDRS, and should not be fooled with unless improving/adding features. 
 //  Developed by Timm Bogner (timmbogner@gmail.com) 
 
-#ifdef DEBUG
+#ifdef FDRS_DEBUG
 #define DBG(a) (Serial.println(a))
 #else
 #define DBG(a)

--- a/FDRS_Sensor/README.md
+++ b/FDRS_Sensor/README.md
@@ -18,7 +18,7 @@ If available and enabled, the device enters deep-sleep. If ```#DEEP_SLEEP``` is 
 The identifier of this individual device. Should be a 16-bit integer (0-65535). 
 ### ```#define GTWY_MAC  0xnn```
 The UNIT_MAC of the gateway that this device will send its data to.
-### ```#define DEBUG```
+### ```#define FDRS_DEBUG```
 This definition enables debug messages to be sent over the serial port. If disabled, no serial interface will be initialized. 
 ### ```#define USE_ESPNOW```
 Enables/disables ESP-NOW.

--- a/FDRS_Sensor/sensor_setup.h
+++ b/FDRS_Sensor/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/ESPNOW_Stress_Test/sensor_setup.h
+++ b/examples/ESPNOW_Stress_Test/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-//#define DEBUG
+//#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Full_System_Example/1_LoRa_Sensor/sensor_setup.h
+++ b/examples/Full_System_Example/1_LoRa_Sensor/sensor_setup.h
@@ -13,7 +13,7 @@
 #define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Full_System_Example/2_ESPNOW_Sensor/sensor_setup.h
+++ b/examples/Full_System_Example/2_ESPNOW_Sensor/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Full_System_Example/3_ESPNOW_Gateway/fdrs_config.h
+++ b/examples/Full_System_Example/3_ESPNOW_Gateway/fdrs_config.h
@@ -3,7 +3,7 @@
 //  GATEWAY 2.000 Configuration
 
 #include <fdrs_globals.h> // Comment if you want to set specific values for this individually
-#define DEBUG
+#define FDRS_DEBUG
 
 #define UNIT_MAC     0x03  // The address of this gateway
 

--- a/examples/Full_System_Example/4_UART_Gateway/fdrs_config.h
+++ b/examples/Full_System_Example/4_UART_Gateway/fdrs_config.h
@@ -3,7 +3,7 @@
 //  GATEWAY 2.000 Configuration
 
 #include <fdrs_globals.h> // Comment if you want to set specific values for this individually
-#define DEBUG
+#define FDRS_DEBUG
 
 #define UNIT_MAC     0x04  // The address of this gateway
 

--- a/examples/Full_System_Example/5_MQTT_Gateway/fdrs_config.h
+++ b/examples/Full_System_Example/5_MQTT_Gateway/fdrs_config.h
@@ -3,7 +3,7 @@
 //  GATEWAY 2.000 Configuration
 
 #include <fdrs_globals.h> // Comment if you want to set specific values for this individually
-#define DEBUG             //Enable debugging information over serial
+#define FDRS_DEBUG             //Enable debugging information over serial
 
 #define UNIT_MAC     0x05  // The address of this gateway
 

--- a/examples/Sensor_Examples/AHT20_fdrs/sensor_setup.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Sensor_Examples/BME280_fdrs/sensor_setup.h
+++ b/examples/Sensor_Examples/BME280_fdrs/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Sensor_Examples/BMP280_fdrs/sensor_setup.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Sensor_Examples/DHT22_fdrs/sensor_setup.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Sensor_Examples/DS18B20_fdrs/sensor_setup.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Sensor_Examples/GenericGPS_fdrs/sensor_setup.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/sensor_setup.h
@@ -13,7 +13,7 @@
 #define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/sensor_setup.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Sensor_Examples/MESB_fdrs/sensor_setup.h
+++ b/examples/Sensor_Examples/MESB_fdrs/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Sensor_Examples/TippingBucket/sensor_setup.h
+++ b/examples/Sensor_Examples/TippingBucket/sensor_setup.h
@@ -13,7 +13,7 @@
 //#define USE_LORA
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/examples/Universal_Gateway_beta/fdrs_config.h
+++ b/examples/Universal_Gateway_beta/fdrs_config.h
@@ -3,7 +3,7 @@
 //  GATEWAY 2.000 Configuration
 
 #include <fdrs_globals.h> // uncomment if you want to set specific values for this sensor in sensor_setup.h
-#define DEBUG
+#define FDRS_DEBUG
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 

--- a/examples/Universal_Gateway_beta/fdrs_gateway.h
+++ b/examples/Universal_Gateway_beta/fdrs_gateway.h
@@ -25,9 +25,9 @@
 
 #define USE_LORA
 
-#define DEBUG
+#define FDRS_DEBUG
 
-#ifdef DEBUG
+#ifdef FDRS_DEBUG
 #define DBG(a) (Serial.println(a))
 #else
 #define DBG(a)

--- a/examples/Universal_Sensor_beta/fdrs_sensor.cpp
+++ b/examples/Universal_Sensor_beta/fdrs_sensor.cpp
@@ -22,7 +22,7 @@ FDRSBase::~FDRSBase(){
 }
 
 void FDRSBase::begin() {
-#ifdef DEBUG
+#ifdef FDRS_DEBUG
     Serial.begin(115200);
 #endif
     DBG("FDRS Sensor ID " + String(_reading_id) + " initializing...");

--- a/examples/Universal_Sensor_beta/fdrs_sensor.h
+++ b/examples/Universal_Sensor_beta/fdrs_sensor.h
@@ -16,8 +16,8 @@
 #define ENABLE_DEBUG 1 
 
 #if ENABLE_DEBUG == 1
-#ifndef DEBUG
-#define DEBUG
+#ifndef FDRS_DEBUG
+#define FDRS_DEBUG
 #endif
 #endif
 
@@ -44,7 +44,7 @@
 #define FDRS_SF LORA_SF
 #endif
 
-#ifdef DEBUG
+#ifdef FDRS_DEBUG
 #define DBG(a) (Serial.println(a))
 #else
 #define DBG(a)

--- a/examples/Universal_Sensor_beta/sensor_setup.h
+++ b/examples/Universal_Sensor_beta/sensor_setup.h
@@ -11,7 +11,7 @@
 
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define DEBUG
+#define FDRS_DEBUG
 
 //SPI Configuration -- Needed only on Boards with multiple SPI interfaces like the ESP32
 #define SPI_SCK 5

--- a/fdrs_functions.h
+++ b/fdrs_functions.h
@@ -4,7 +4,7 @@
 //  This is the 'meat and potatoes' of FDRS, and should not be fooled with unless improving/adding features. 
 //  Developed by Timm Bogner (timmbogner@gmail.com) 
 
-#ifdef DEBUG
+#ifdef FDRS_DEBUG
 #define DBG(a) (Serial.println(a))
 #else
 #define DBG(a)

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -25,7 +25,7 @@
 #define FDRS_SF LORA_SF
 #endif
 
-#ifdef DEBUG
+#ifdef FDRS_DEBUG
 #define DBG(a) (Serial.println(a))
 #else
 #define DBG(a)
@@ -50,7 +50,7 @@ DataReading fdrsData[espnow_size];
 uint8_t data_count = 0;
 
 void beginFDRS() {
-#ifdef DEBUG
+#ifdef FDRS_DEBUG
   Serial.begin(115200);
 #endif
   DBG("FDRS Sensor ID " + String(READING_ID) + " initializing...");

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,7 +11,7 @@ DataReading	KEYWORD1
 ##########################################################
 # Methods and Functions (KEYWORD2)
 ##########################################################
-DBG	KEYWORD2
+FDRS_DBG	KEYWORD2
 beginFDRS	KEYWORD2
 bufferESPNOW	KEYWORD2
 bufferLoRa	KEYWORD2
@@ -31,8 +31,7 @@ transmitLoRa	KEYWORD2
 ##########################################################
 # Literals (LITERAL1)
 ##########################################################
-DEBUG	LITERAL1
-DEBUG	LITERAL1
+FDRS_DEBUG	LITERAL1
 DEEP_SLEEP	LITERAL1
 FDRS_BAND	LITERAL1
 FDRS_GLOBALS	LITERAL1


### PR DESCRIPTION
As mentioned in #47 the names DEBUG and DBG prevent the project to compile on PlatformIO.
It also will prevent issues when other libraries will be used in the project as it is likely that DEBUG and DBG may be used there as well.

In addition I removed a duplicate entry from keywords.txt