### PR TITLE
Use internal NTP api

### DIFF
--- a/FDRS_Gateway/FDRS_Gateway.ino
+++ b/FDRS_Gateway/FDRS_Gateway.ino
@@ -18,7 +18,6 @@
 #ifdef USE_WIFI
 #include <PubSubClient.h>
 #include <WiFiUdp.h>
-#include <NTPClient.h>
 #endif
 #ifdef USE_LORA
 #include <LoRa.h>
@@ -32,6 +31,9 @@
 #endif
 #ifdef USE_FS_LOG
 #include <LittleFS.h>
+#endif
+#if defined (USE_SD_LOG) || defined (USE_FS_LOG)
+#include <time.h>
 #endif
 //#include <fdrs_functions.h>  //Use global functions file
 #include "fdrs_functions.h"  //Use local functions file
@@ -149,14 +151,6 @@ void loop() {
   }
   client.loop(); // for recieving incoming messages and maintaining connection
 
-  timeClient.update();  //update internal clock if possible
-  #endif
-  #if defined (USE_SD_LOG) || defined (USE_FS_LOG)
-  unsigned long current_millis = millis();
-  if(current_millis-last_millis >= 1000){
-    seconds_since_reset+=(current_millis-last_millis)/1000;
-    last_millis=current_millis;
-  }
   #endif
   if (newData) {
     switch (newData) {

--- a/FDRS_Gateway/fdrs_functions.h
+++ b/FDRS_Gateway/fdrs_functions.h
@@ -89,8 +89,6 @@ uint8_t LoRa2[] =         {mac_prefix[3], mac_prefix[4], LORA2_PEER};
 #endif
 
 #if defined (USE_SD_LOG) || defined (USE_FS_LOG)
-unsigned long last_millis = 0;
-unsigned long seconds_since_reset = 0;
 char logBuffer[512];
 uint16_t logBufferPos = 0; // datatype depends on size of sdBuffer
 uint32_t timeLOGBUF = 0;
@@ -131,8 +129,6 @@ CRGB leds[NUM_LEDS];
 #endif
 #ifdef USE_WIFI
 PubSubClient client(espClient);
-WiFiUDP ntpUDP;
-NTPClient timeClient(ntpUDP);
 const char* ssid = FDRS_WIFI_SSID;
 const char* password = FDRS_WIFI_PASS;
 const char* mqtt_server = FDRS_MQTT_ADDR;
@@ -220,11 +216,7 @@ void sendLog()
   for (int i = 0; i < ln; i++)
   {
     char linebuf[34]; // size depends on resulting length of the formatting string
-    #ifdef USE_WIFI
-    sprintf(linebuf, "%ld,%d,%d,%g\r\n", timeClient.getEpochTime(), theData[i].id, theData[i].t, theData[i].d);
-    #else
-    sprintf(linebuf, "%ld,%d,%d,%g\r\n", seconds_since_reset, theData[i].id, theData[i].t, theData[i].d);
-    #endif
+    sprintf(linebuf, "%lld,%d,%d,%g\r\n", time(nullptr), theData[i].id, theData[i].t, theData[i].d);
 
     if (logBufferPos+strlen(linebuf) >= (sizeof(logBuffer)/sizeof(char))) // if buffer would overflow, release first
     {


### PR DESCRIPTION
As discussed in #60 I replaced the NTPClient library with the internal ntp timekeeping api.

This reduces some complexity very nicely.