### PR TITLE
Clean up of #72

### DIFF
--- a/FDRS_Gateway/README.md
+++ b/FDRS_Gateway/README.md
@@ -20,6 +20,11 @@ The UNIT_MAC is the ESP-NOW and LoRa address of the gateway. This is the address
 This definition enables debug messages to be sent over the serial port. If disabled, the USB serial port is still used to echo data being sent via the sendSerial() command.
 ### ```#define RXD2 (pin)``` and ```TXD2 (pin)```
 These are the pins for inter-device serial communication. The single ESP8266 serial interface is not configurable, and thus these options only apply to ESP32 boards. 
+
+### ```#define USE_ESPNOW```
+Enables ESP-NOW.
+USE_ESPNOW and USE_WIFI must not be activated at the same time! 
+
 ### ```#define USE_LORA```
 Enables LoRa. Make sure that you set the LoRa module configuration parameters in the lines below.
 

--- a/FDRS_Gateway/fdrs_functions.h
+++ b/FDRS_Gateway/fdrs_functions.h
@@ -19,6 +19,7 @@ enum {
   event_lora1,
   event_lora2
 };
+
 #ifdef FDRS_DEBUG
 #define DBG(a) (Serial.println(a))
 #else
@@ -31,31 +32,98 @@ enum {
 #define UART_IF Serial
 #endif
 
-#ifdef FDRS_GLOBALS
-#define FDRS_WIFI_SSID GLOBAL_SSID
-#define FDRS_WIFI_PASS GLOBAL_PASS
-#define FDRS_MQTT_ADDR GLOBAL_MQTT_ADDR
-#define FDRS_MQTT_PORT GLOBAL_MQTT_PORT
-#define FDRS_MQTT_USER GLOBAL_MQTT_USER
-#define FDRS_MQTT_PASS GLOBAL_MQTT_PASS
-#define FDRS_BAND GLOBAL_LORA_BAND
-#define FDRS_SF GLOBAL_LORA_SF
-#else
+// enable to get detailed info from where single configuration macros have been taken
+#define DEBUG_NODE_CONFIG
+
+#ifdef USE_WIFI
+
+// select WiFi SSID configuration
+#if defined(WIFI_SSID)
 #define FDRS_WIFI_SSID WIFI_SSID
+#elif defined (GLOBAL_SSID)
+#define FDRS_WIFI_SSID GLOBAL_SSID
+#else 
+// ASSERT("NO WiFi SSID defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+#endif //WIFI_SSID
+
+// select WiFi password 
+#if defined(WIFI_PASS)
 #define FDRS_WIFI_PASS WIFI_PASS
+#elif defined (GLOBAL_PASS)
+#define FDRS_WIFI_PASS GLOBAL_PASS
+#else 
+// ASSERT("NO WiFi password defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+#endif //WIFI_PASS
+
+// select MQTT server address
+#if defined(MQTT_ADDR)
 #define FDRS_MQTT_ADDR MQTT_ADDR
+#elif defined (GLOBAL_MQTT_ADDR)
+#define FDRS_MQTT_ADDR GLOBAL_MQTT_ADDR
+#else 
+// ASSERT("NO MQTT address defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+#endif //MQTT_ADDR
+
+// select MQTT server port
+#if defined(MQTT_PORT)
 #define FDRS_MQTT_PORT MQTT_PORT
+#elif defined (GLOBAL_MQTT_PORT)
+#define FDRS_MQTT_PORT GLOBAL_MQTT_PORT
+#else 
+#define FDRS_MQTT_PORT 1883
+#endif //MQTT_PORT
+
+// select MQTT user name
+#if defined(MQTT_USER)
 #define FDRS_MQTT_USER MQTT_USER
+#elif defined (GLOBAL_MQTT_USER)
+#define FDRS_MQTT_USER GLOBAL_MQTT_USER
+#else 
+// ASSERT("NO MQTT user defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+#endif //MQTT_USER
+
+// select MQTT user password
+#if defined(MQTT_PASS)
 #define FDRS_MQTT_PASS MQTT_PASS
-#define FDRS_BAND LORA_BAND
-#define FDRS_SF LORA_SF
-#endif
+#elif defined (GLOBAL_MQTT_PASS)
+#define FDRS_MQTT_PASS GLOBAL_MQTT_PASS
+#else 
+// ASSERT("NO MQTT password defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+#endif //MQTT_PASS
 
 #if defined (MQTT_AUTH) || defined (GLOBAL_MQTT_AUTH)
 #define FDRS_MQTT_AUTH
-#endif
+#endif //MQTT_AUTH
+
+#endif //USE_WIFI
+
+#ifdef USE_LORA
+
+// select LoRa band configuration
+#if defined(LORA_BAND)
+#define FDRS_BAND LORA_BAND
+#elif defined (GLOBAL_LORA_BAND)
+#define FDRS_BAND GLOBAL_LORA_BAND
+#else 
+// ASSERT("NO LORA-BAND defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+#endif //LORA_BAND
+
+// select LoRa SF configuration
+#if defined(LORA_SF)
+#define FDRS_SF LORA_SF
+#elif defined (GLOBAL_LORA_SF)
+#define FDRS_SF GLOBAL_LORA_SF
+#else 
+// ASSERT("NO LORA-SF defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+#endif //LORA_SF
+
+#endif //USE_LORA
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
+
+#ifdef DEBUG_NODE_CONFIG
+#include "fdrs_checkConfig.h"
+#endif
 
 typedef struct __attribute__((packed)) DataReading {
   float d;
@@ -103,6 +171,7 @@ DataReading theData[256];
 uint8_t ln;
 uint8_t newData = event_clear;
 
+#ifdef USE_ESPNOW
 DataReading ESPNOW1buffer[256];
 uint8_t lenESPNOW1 = 0;
 uint32_t timeESPNOW1 = 0;
@@ -112,12 +181,16 @@ uint32_t timeESPNOW2 = 0;
 DataReading ESPNOWGbuffer[256];
 uint8_t lenESPNOWG = 0;
 uint32_t timeESPNOWG = 0;
+#endif //USE_ESPNOW
+
 DataReading SERIALbuffer[256];
 uint8_t lenSERIAL = 0;
 uint32_t timeSERIAL = 0;
 DataReading MQTTbuffer[256];
 uint8_t lenMQTT = 0;
 uint32_t timeMQTT = 0;
+
+#ifdef USE_LORA
 DataReading LORAGbuffer[256];
 uint8_t lenLORAG = 0;
 uint32_t timeLORAG = 0;
@@ -127,28 +200,31 @@ uint32_t timeLORA1 = 0;
 DataReading LORA2buffer[256];
 uint8_t lenLORA2 = 0;
 uint32_t timeLORA2 = 0;
+#endif //USE_LORA
 
-WiFiClient espClient;
 #ifdef USE_LED
 CRGB leds[NUM_LEDS];
-#endif
+#endif //USE_LED
+
 #ifdef USE_WIFI
+WiFiClient espClient;
 PubSubClient client(espClient);
 const char* ssid = FDRS_WIFI_SSID;
 const char* password = FDRS_WIFI_PASS;
 const char* mqtt_server = FDRS_MQTT_ADDR;
 const int mqtt_port = FDRS_MQTT_PORT;
-#endif
+
 #ifdef FDRS_MQTT_AUTH
 const char* mqtt_user = FDRS_MQTT_USER;
 const char* mqtt_pass = FDRS_MQTT_PASS;
 #else
 const char* mqtt_user = NULL;
 const char* mqtt_pass = NULL;
-#endif
+#endif //FDRS_MQTT_AUTH
 
+#endif //USE_WIFI
 
-
+#ifdef USE_ESPNOW
 // Set ESP-NOW send and receive callbacks for either ESP8266 or ESP32
 #if defined(ESP8266)
 void OnDataSent(uint8_t *mac_addr, uint8_t sendStatus) {
@@ -173,6 +249,8 @@ void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
   }
   newData = event_espnowg;
 }
+#endif //USE_ESPNOW
+
 void getSerial() {
   String incomingString =  UART_IF.readStringUntil('\n');
   DynamicJsonDocument doc(24576);
@@ -195,6 +273,7 @@ void getSerial() {
 
   }
 }
+
 #if defined (USE_SD_LOG) || defined (USE_FS_LOG)
 void releaseLogBuffer()
 {
@@ -214,6 +293,7 @@ void releaseLogBuffer()
   logBufferPos = 0;
 }
 #endif
+
 void sendLog()
 {
   #if defined (USE_SD_LOG) || defined (USE_FS_LOG)
@@ -230,8 +310,9 @@ void sendLog()
     memcpy(&logBuffer[logBufferPos], linebuf, strlen(linebuf)); //append line to buffer
     logBufferPos+=strlen(linebuf);
   }
-  #endif
+  #endif //USE_xx_LOG
 }
+
 void reconnect(short int attempts, bool silent) {
 #ifdef USE_WIFI
 
@@ -257,11 +338,13 @@ void reconnect(short int attempts, bool silent) {
   }
 
   if (!silent) DBG(" Connecting MQTT failed.");
-#endif
+#endif //USE_WIFI
 }
+
 void reconnect(int attempts) {
   reconnect(attempts, false);
 }
+
 void mqtt_callback(char* topic, byte * message, unsigned int length) {
   String incomingString;
   DBG(topic);
@@ -288,13 +371,14 @@ void mqtt_callback(char* topic, byte * message, unsigned int length) {
 
   }
 }
+
 void mqtt_publish(const char* payload) {
 #ifdef USE_WIFI
   if (!client.publish(TOPIC_DATA, payload)) {
     DBG(" Error on sending MQTT");
     sendLog();
   }
-#endif
+#endif //USE_WIFI
 }
 
 void getLoRa() {
@@ -320,10 +404,11 @@ void getLoRa() {
       newData = event_lorag;
     }
   }
-#endif
+#endif //USE_LORA
 }
 
 void sendESPNOW(uint8_t address) {
+#ifdef USE_ESPNOW
   DBG("Sending ESP-NOW.");
   uint8_t NEWPEER[] = {MAC_PREFIX, address};
 #if defined(ESP32)
@@ -350,6 +435,7 @@ void sendESPNOW(uint8_t address) {
   }
   esp_now_send(NEWPEER, (uint8_t *) &thePacket, j * sizeof(DataReading));
   esp_now_del_peer(NEWPEER);
+#endif //USE_ESPNOW
 }
 
 void sendSerial() {
@@ -381,10 +467,11 @@ void sendMQTT() {
   String outgoingString;
   serializeJson(doc, outgoingString);
   mqtt_publish((char*) outgoingString.c_str());
-#endif
+#endif //USE_WIFI
 }
 
 void bufferESPNOW(uint8_t interface) {
+#ifdef USE_ESPNOW
   DBG("Buffering ESP-NOW.");
 
   switch (interface) {
@@ -407,7 +494,9 @@ void bufferESPNOW(uint8_t interface) {
       lenESPNOW2 +=  ln;
       break;
   }
+#endif USE_ESPNOW
 }
+
 void bufferSerial() {
   DBG("Buffering Serial.");
   for (int i = 0; i < ln; i++) {
@@ -416,6 +505,7 @@ void bufferSerial() {
   lenSERIAL += ln;
   //UART_IF.println("SENDSERIAL:" + String(lenSERIAL) + " ");
 }
+
 void bufferMQTT() {
   DBG("Buffering MQTT.");
   for (int i = 0; i < ln; i++) {
@@ -423,13 +513,16 @@ void bufferMQTT() {
   }
   lenMQTT += ln;
 }
+
 //void bufferLoRa() {
 //  for (int i = 0; i < ln; i++) {
 //    LORAbuffer[lenLORA + i] = theData[i];
 //  }
 //  lenLORA += ln;
 //}
+
 void bufferLoRa(uint8_t interface) {
+#ifdef USE_LORA
   DBG("Buffering LoRa.");
   switch (interface) {
     case 0:
@@ -451,9 +544,11 @@ void bufferLoRa(uint8_t interface) {
       lenLORA2 += ln;
       break;
   }
+#endif //USE_LORA
 }
 
 void releaseESPNOW(uint8_t interface) {
+#ifdef USE_ESPNOW
   DBG("Releasing ESP-NOW.");
   switch (interface) {
     case 0:
@@ -505,7 +600,9 @@ void releaseESPNOW(uint8_t interface) {
         break;
       }
   }
+#endif USE_ESPNOW
 }
+
 #ifdef USE_LORA
 void transmitLoRa(uint8_t* mac, DataReading * packet, uint8_t len) {
   DBG("Transmitting LoRa.");
@@ -578,6 +675,7 @@ void releaseLoRa(uint8_t interface) {
   }
 #endif //USE_LORA
 }
+
 void releaseSerial() {
   DBG("Releasing Serial.");
   DynamicJsonDocument doc(24576);
@@ -590,6 +688,7 @@ void releaseSerial() {
   UART_IF.println();
   lenSERIAL = 0;
 }
+
 void releaseMQTT() {
 #ifdef USE_WIFI
   DBG("Releasing MQTT.");
@@ -603,9 +702,11 @@ void releaseMQTT() {
   serializeJson(doc, outgoingString);
   mqtt_publish((char*) outgoingString.c_str());
   lenMQTT = 0;
-#endif
+#endif //USE_WIFI
 }
+
 void begin_espnow() {
+#ifdef USE_ESPNOW
   DBG("Initializing ESP-NOW!");
   WiFi.mode(WIFI_STA);
   WiFi.disconnect();
@@ -659,6 +760,7 @@ void begin_espnow() {
 #endif
 #endif //ESP8266
   DBG(" ESP-NOW Initialized.");
+#endif //USE_ESPNOW
 }
 
 void begin_lora() {
@@ -673,10 +775,9 @@ void begin_lora() {
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);
-  DBG(" LoRa initialized.");
   DBG("LoRa Band: " + String(FDRS_BAND));
   DBG("LoRa SF  : " + String(FDRS_SF));
-#endif //USE_LORA
+#endif // USE_LORA
 }
 
 void begin_SD() {
@@ -707,7 +808,7 @@ void begin_FS() {
   {
     DBG(" LittleFS initialized");
   }
-#endif
+#endif // USE_FS_LOG
 }
 
 #endif //__FDRS_FUNCTIONS_H__

--- a/FDRS_Gateway/fdrs_gateway_config.h
+++ b/FDRS_Gateway/fdrs_gateway_config.h
@@ -16,8 +16,11 @@
 #define MQTT_ACT          
 #define LORAG_ACT      sendSerial();
 
+// protocols -- Define which protocols the gateways should handle.
+// Warning: ESP-NOW and WiFi are mutual exclusive!
 //#define USE_LORA
-//#define USE_WIFI      //Used only for MQTT gateway
+#define USE_ESPNOW  
+//#define USE_WIFI    //Used only for MQTT gateway
 
 // Peer addresses
 #define ESPNOW1_PEER  0x0E  // ESPNOW1 Address 
@@ -77,14 +80,14 @@
 #define NUM_LEDS    4
 
 // WiFi and MQTT Credentials -- Needed for MQTT only if "fdrs_globals.h" is not included
-#define WIFI_SSID   "Your SSID"  
-#define WIFI_PASS   "Your Password"
-#define MQTT_ADDR   "192.168.0.8"
-#define MQTT_PORT   1883 // Default MQTT port is 1883
+//#define WIFI_SSID   "Your SSID"  
+//#define WIFI_PASS   "Your Password"
+//#define MQTT_ADDR   "192.168.0.8"
+//#define MQTT_PORT   1883 // Default MQTT port is 1883
 
 //#define MQTT_AUTH   //Enable MQTT authentication 
-#define MQTT_USER   "Your MQTT Username"
-#define MQTT_PASS   "Your MQTT Password"
+//#define MQTT_USER   "Your MQTT Username"
+//#define MQTT_PASS   "Your MQTT Password"
 
 // MQTT Topics
 #define TOPIC_DATA "fdrs/data"

--- a/FDRS_Sensor/FDRS_Sensor.ino
+++ b/FDRS_Sensor/FDRS_Sensor.ino
@@ -5,6 +5,7 @@
 //  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //  An example of how to send data using "fdrs_sensor.h".
 //
+
 #include "fdrs_sensor_config.h"
 
 //#include <fdrs_sensor.h>   //Use global functions file

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -18,7 +18,7 @@
 #endif
 
 // enable to get detailed info from where single configuration macros have been taken
-//#define DEBUG_NODE_CONFIG
+#define DEBUG_NODE_CONFIG
 
 #ifdef USE_LORA
 
@@ -50,6 +50,10 @@
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 
+#ifdef DEBUG_NODE_CONFIG
+#include "fdrs_checkConfig.h"
+#endif
+
 typedef struct __attribute__((packed)) DataReading {
   float d;
   uint16_t id;
@@ -67,39 +71,12 @@ DataReading fdrsData[espnow_size];
 uint8_t data_count = 0;
 
 
-void debugConfig() {
-#ifdef USE_LORA
-	
-	DBG("----------------------------------------------------");
-	DBG("SENSOR LORA CONFIG");
-	DBG("----------------------------------------------------");
-#if defined(LORA_BAND)
-	DBG("LoRa Band used from LORA_BAND       : " + String(FDRS_BAND));
-#elif defined (GLOBAL_LORA_BAND)
-	DBG("LoRa Band used from GLOBAL_LORA_BAND: " + String(FDRS_BAND));
-#else 
-	DBG("NO LORA-BAND defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //LORA-BAND
-
-#if defined(LORA_SF)
-	DBG("LoRa SF used from LORA_SF           : " + String(FDRS_SF));
-#elif defined (GLOBAL_LORA_SF)
-	DBG("LoRa SF used from GLOBAL_LORA_SF    : " + String(FDRS_SF));
-#else 
-//	ASSERT("NO LORA-SF defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	DBG("NO LORA-SF defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //LORA-BAND
-	DBG("----------------------------------------------------");
-	DBG("");
-#endif //USE_LORA
-}
-
-
 void beginFDRS() {
 #ifdef FDRS_DEBUG
   Serial.begin(115200);
+  // find out the reset reason
+  esp_reset_reason_t resetReason;
+  resetReason = esp_reset_reason();
 #endif
   DBG("FDRS Sensor ID " + String(READING_ID) + " initializing...");
   DBG(" Gateway: " + String (GTWY_MAC, HEX));
@@ -137,7 +114,7 @@ void beginFDRS() {
   }
 #endif
   DBG(" ESP-NOW Initialized.");
-#endif
+#endif //USE_ESPNOW
 #ifdef USE_LORA
   DBG("Initializing LoRa!");
 #ifdef ESP32
@@ -150,13 +127,16 @@ void beginFDRS() {
   }
   LoRa.setSpreadingFactor(FDRS_SF);
   DBG(" LoRa Initialized.");
-#ifdef DEBUG_NODE_CONFIG
-  debugConfig();
-#else
+
   DBG("LoRa Band: " + String(FDRS_BAND));
   DBG("LoRa SF  : " + String(FDRS_SF));
-#endif //DEBUG_NODE_CONFIG
 #endif // USE_LORA
+#ifdef DEBUG_NODE_CONFIG
+  if (resetReason != ESP_RST_DEEPSLEEP) {
+    checkConfig();
+  }
+#endif //DEBUG_NODE_CONFIG
+
 }
 
 void transmitLoRa(uint8_t* mac, DataReading * packet, uint8_t len) {

--- a/examples/1_LoRa_Sensor/1_LoRa_Sensor.ino
+++ b/examples/1_LoRa_Sensor/1_LoRa_Sensor.ino
@@ -2,7 +2,7 @@
 //
 //  Basic Sensor Example
 //
-//  Developed by Timm Bogner (bogner1@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
+//  Developed by Timm Bogner (timmbogner@gmail.com) for Sola Gratia Farm in Urbana, Illinois, USA.
 //  An example of how to send data using "fdrs_sensor.h".
 //
 

--- a/examples/3_ESPNOW_Gateway/fdrs_gateway_config.h
+++ b/examples/3_ESPNOW_Gateway/fdrs_gateway_config.h
@@ -16,7 +16,10 @@
 #define MQTT_ACT          
 #define LORAG_ACT      
 
+// protocols -- Define which protocols the gateways should handle.
+// Warning: ESP-NOW and WiFi are mutual exclusive!
 //#define USE_LORA
+#define USE_ESPNOW  
 //#define USE_WIFI    //Used only for MQTT gateway
 
 // Peer addresses

--- a/examples/4_UART_Gateway/4_UART_Gateway.ino
+++ b/examples/4_UART_Gateway/4_UART_Gateway.ino
@@ -44,7 +44,18 @@ void setup() {
   Serial.begin(115200);
   UART_IF.begin(115200, SERIAL_8N1, RXD2, TXD2);
 #endif
+
   DBG("Address:" + String (UNIT_MAC, HEX));
+
+#ifdef DEBUG_NODE_CONFIG
+  // find out the reset reason
+  esp_reset_reason_t resetReason;
+  resetReason = esp_reset_reason();
+  if (resetReason != ESP_RST_DEEPSLEEP) {
+    checkConfig();
+  }
+#endif //DEBUG_NODE_CONFIG
+
 #ifdef USE_LED
   FastLED.addLeds<WS2812B, LED_PIN, GRB>(leds, NUM_LEDS);
   leds[0] = CRGB::Blue;

--- a/examples/4_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/4_UART_Gateway/fdrs_gateway_config.h
@@ -16,8 +16,10 @@
 #define MQTT_ACT          
 #define LORAG_ACT      sendSerial();
 
+// protocols -- Define which protocols the gateways should handle.
+// Warning: ESP-NOW and WiFi are mutual exclusive!
 #define USE_LORA
-#define USE_ESPNOW // Missing! Gateways do not have to be ESPNOW activated. It also is making config much easier. Used it there. 
+#define USE_ESPNOW  
 //#define USE_WIFI    //Used only for MQTT gateway
 
 // Peer addresses

--- a/examples/4_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/4_UART_Gateway/fdrs_gateway_config.h
@@ -17,6 +17,7 @@
 #define LORAG_ACT      sendSerial();
 
 #define USE_LORA
+#define USE_ESPNOW // Missing! Gateways do not have to be ESPNOW activated. It also is making config much easier. Used it there. 
 //#define USE_WIFI    //Used only for MQTT gateway
 
 // Peer addresses

--- a/examples/5_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/5_MQTT_Gateway/fdrs_gateway_config.h
@@ -16,8 +16,11 @@
 #define MQTT_ACT          
 #define LORAG_ACT      
 
+// protocols -- Define which protocols the gateways should handle.
+// Warning: ESP-NOW and WiFi are mutual exclusive!
 //#define USE_LORA
-#define USE_WIFI      //Used only for MQTT gateway
+//#define USE_ESPNOW  
+#define USE_WIFI    //Used only for MQTT gateway
 
 // Peer addresses
 #define ESPNOW1_PEER  0x0E  // ESPNOW1 Address 

--- a/fdrs_checkConfig.h
+++ b/fdrs_checkConfig.h
@@ -1,0 +1,219 @@
+
+#ifndef __FDRS_CHECKCONFIG_h__
+#define __FDRS_CHECKCONFIG_h__
+
+char* separatorLine2 = "----------------------------------------------------";
+
+// helper function for a nice little header above each section
+void printSmallSectionHeader(char* headerText) {
+	char * separatorLine   = "----------------------------------------------------";
+
+	DBG(separatorLine);
+	DBG(headerText);
+	//DBG(separatorLine);
+}
+
+// helper function for a nice little header above each section
+void printSectionHeader(char* headerText) {
+	char * separatorLine   = "----------------------------------------------------";
+
+	DBG(separatorLine);
+	DBG(headerText);
+	DBG(separatorLine);
+}
+
+// helper function for a nice little header above each section
+void printConfigHeader(char* headerText) {
+	char * headerAndFooter = "====================================================";
+
+	DBG(headerAndFooter);
+	DBG(headerText);
+	DBG(headerAndFooter);
+}
+
+// check which protocols are activated and which are deactivated
+void printActivatedProtocols() {
+	// current candidates are: WIFI, ESPNOW, LORA, MQTT, ???
+	printSectionHeader("ACTIVATED PROTOCOLS");
+
+#ifdef USE_LORA
+	DBG("LoRa  : ENABLED");
+#else
+	DBG("LoRa  : DISABLED");
+#endif
+
+#ifdef USE_ESPNOW
+	DBG("ESPNow: ENABLED");
+#else
+	DBG("ESPNow: DISABLED");
+#endif
+
+#ifdef USE_WIFI
+	DBG("WiFi  : ENABLED");
+#else
+	DBG("WiFi  : DISABLED");
+#endif
+
+}
+
+
+void printEspnowDetails() {
+#ifdef USE_ESPNOW
+
+#ifdef UNIT_MAC
+	printSmallSectionHeader("ESP-Now Details:");
+	DBG("Peer 1 address: " + String(ESPNOW1_PEER, HEX));
+	DBG("Peer 2 address: " + String(ESPNOW2_PEER, HEX));
+#endif //UNIT_MAC
+
+#endif //USE_ESPNOW
+}
+
+void printWifiDetails() {
+#ifdef USE_WIFI
+	printSmallSectionHeader("WiFi Details:");
+
+#if defined(WIFI_SSID)
+	DBG("WiFi SSID used from WIFI_SSID            : " + String(FDRS_WIFI_SSID));
+#elif defined (GLOBAL_SSID)
+	DBG("WiFi SSID used from GLOBAL_SSID          : " + String(FDRS_WIFI_SSID));
+#else 
+	DBG("NO WiFi SSID defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+	//exit(0);
+#endif //WIFI_SSID
+
+#if defined(WIFI_PASS)
+	DBG("WiFi password used from WIFI_PASS        : " + String(FDRS_WIFI_PASS));
+#elif defined (GLOBAL_SSID)
+	DBG("WiFi password used from GLOBAL_PASS      : " + String(FDRS_WIFI_PASS));
+#else 
+	DBG("NO WiFi password defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+	//exit(0);
+#endif //WIFI_PASS
+
+	printSmallSectionHeader("MQTT BROKER CONFIG:");
+
+#if defined(MQTT_ADDR)
+	DBG("MQTT address used from MQTT_ADDR         : " + String(FDRS_MQTT_ADDR));
+#elif defined (GLOBAL_MQTT_ADDR)
+	DBG("MQTT address used from GLOBAL_MQTT_ADDR  : " + String(FDRS_MQTT_ADDR));
+#else 
+	DBG("NO MQTT address defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+	//exit(0);
+#endif //MQTT_ADDR
+
+#if defined(MQTT_PORT)
+	DBG("MQTT port used from MQTT_PORT            : " + String(FDRS_MQTT_PORT));
+#elif defined (GLOBAL_MQTT_PORT)
+	DBG("MQTT port used from GLOBAL_MQTT_ADDR     : " + String(FDRS_MQTT_PORT));
+#else 
+	DBG("Using default MQTT port                  : " + String(FDRS_MQTT_PORT));
+#endif //MQTT_PORT
+
+#ifdef FDRS_MQTT_AUTH
+	printSmallSectionHeader("MQTT AUTHENTIFICATION CONFIG:");
+//GLOBAL_MQTT_AUTH
+#if defined(MQTT_USER)
+	DBG("MQTT username used from MQTT_USER        : " + String(FDRS_MQTT_USER));
+#elif defined (GLOBAL_MQTT_USER)
+	DBG("MQTT username used from GLOBAL_MQTT_USER : " + String(FDRS_MQTT_USER));
+#else 
+	DBG("NO MQTT username defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+	//exit(0);
+#endif //MQTT_USER
+
+#if defined(MQTT_PASS)
+	DBG("MQTT password used from MQTT_PASS        : " + String(FDRS_MQTT_PASS));
+#elif defined (GLOBAL_MQTT_PASS)
+	DBG("MQTT password used from GLOBAL_MQTT_PASS : " + String(FDRS_MQTT_PASS));
+#else 
+	DBG("NO MQTT password defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+	//exit(0);
+#endif //MQTT_PASS
+
+#endif //FDRS_MQTT_AUTH
+	DBG("----------------------------------------------------");
+	DBG(separatorLine2);
+
+#endif //USE_WIFI
+
+
+}
+
+void printLoraDetails() {
+#ifdef USE_LORA
+	printSmallSectionHeader("LoRa Details:");
+	
+#if defined(LORA_BAND)
+	DBG("LoRa Band used from LORA_BAND       : " + String(FDRS_BAND));
+#elif defined (GLOBAL_LORA_BAND)
+	DBG("LoRa Band used from GLOBAL_LORA_BAND: " + String(FDRS_BAND));
+#else 
+	DBG("NO LORA-BAND defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+	//exit(0);
+#endif //LORA-BAND
+
+#if defined(LORA_SF)
+	DBG("LoRa SF used from LORA_SF           : " + String(FDRS_SF));
+#elif defined (GLOBAL_LORA_SF)
+	DBG("LoRa SF used from GLOBAL_LORA_SF    : " + String(FDRS_SF));
+#else 
+//	ASSERT("NO LORA-SF defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+	DBG("NO LORA-SF defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
+	//exit(0);
+#endif //LORA-SF
+
+#ifdef UNIT_MAC
+	DBG("LoRa peers");
+	DBG("Peer 1 address: " + String(LORA1_PEER, HEX));
+	DBG("Peer 2 address: " + String(LORA2_PEER, HEX));
+#endif //UNIT_MAC
+
+#endif //USE_LORA
+}
+
+
+void checkConfig() {
+	printConfigHeader("NODE CONFIGURATION OVERVIEW");
+#ifdef UNIT_MAC
+	DBG("Node Type       : Gateway");
+	DBG("Gateway ID      : " + String(UNIT_MAC, HEX));
+#elif defined (READING_ID)
+	DBG("Node Type       : Sensor");
+	DBG("Reading ID      : " + String(READING_ID));
+	DBG("Sensor's Gateway: " + String(GTWY_MAC, HEX));
+#else
+	DBG("Node Type       : UNKNOWN!");
+	DBG("Please check config!");
+	DBG("If you have just created a new node type,");
+	DBG("please add it's config check to:");
+	DGB("fdrs_checkConfig.h");
+#endif
+
+	//printConfigHeader("FULL CONFIG OVERVIEW");
+	
+	printActivatedProtocols();
+	
+	printSmallSectionHeader("PROTOCOL DETAILS");
+
+#ifdef USE_LORA
+	printLoraDetails();
+#endif
+
+// why is USE_ESPNOW not defined for gateways? This should be implemented as not every gateway has to be an ESP-NOW gateway!
+#ifdef USE_ESPNOW
+	printEspnowDetails();
+#endif
+
+#ifdef USE_WIFI
+	printWifiDetails();
+#endif
+
+
+
+	DBG("----------------------------------------------------");
+	DBG("");
+}
+
+#endif //__FDRS_CHECKCONFIG_h__
+

--- a/fdrs_functions.h
+++ b/fdrs_functions.h
@@ -91,6 +91,10 @@ enum {
 // ASSERT("NO MQTT password defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
 #endif //MQTT_PASS
 
+#if defined (MQTT_AUTH) || defined (GLOBAL_MQTT_AUTH)
+#define FDRS_MQTT_AUTH
+#endif //MQTT_AUTH
+
 #endif //USE_WIFI
 
 #ifdef USE_LORA
@@ -115,11 +119,11 @@ enum {
 
 #endif //USE_LORA
 
-#if defined (MQTT_AUTH) || defined (GLOBAL_MQTT_AUTH)
-#define FDRS_MQTT_AUTH
-#endif
-
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
+
+#ifdef DEBUG_NODE_CONFIG
+#include "fdrs_checkConfig.h"
+#endif
 
 typedef struct __attribute__((packed)) DataReading {
   float d;
@@ -210,103 +214,6 @@ const char* mqtt_pass = FDRS_MQTT_PASS;
 const char* mqtt_user = NULL;
 const char* mqtt_pass = NULL;
 #endif
-
-void debugConfig() {
-
-#ifdef USE_WIFI
-	DBG("----------------------------------------------------");
-	DBG("SENSOR WIFI CONFIG:");
-#if defined(WIFI_SSID)
-	DBG("WiFi SSID used from WIFI_SSID            : " + String(FDRS_WIFI_SSID));
-#elif defined (GLOBAL_SSID)
-	DBG("WiFi SSID used from GLOBAL_SSID          : " + String(FDRS_WIFI_SSID));
-#else 
-	DBG("NO WiFi SSID defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //WIFI_SSID
-
-#if defined(WIFI_PASS)
-	DBG("WiFi password used from WIFI_PASS        : " + String(FDRS_WIFI_PASS));
-#elif defined (GLOBAL_SSID)
-	DBG("WiFi password used from GLOBAL_PASS      : " + String(FDRS_WIFI_PASS));
-#else 
-	DBG("NO WiFi password defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //WIFI_PASS
-
-#if defined(MQTT_ADDR)
-	DBG("MQTT address used from MQTT_ADDR         : " + String(FDRS_MQTT_ADDR));
-#elif defined (GLOBAL_MQTT_ADDR)
-	DBG("MQTT address used from GLOBAL_MQTT_ADDR  : " + String(FDRS_MQTT_ADDR));
-#else 
-	DBG("NO MQTT address defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //MQTT_ADDR
-
-
-#if defined(MQTT_PORT)
-	DBG("MQTT port used from MQTT_PORT            : " + String(FDRS_MQTT_PORT));
-#elif defined (GLOBAL_MQTT_PORT)
-	DBG("MQTT port used from GLOBAL_MQTT_ADDR     : " + String(FDRS_MQTT_PORT));
-#else 
-	DBG("Using default MQTT port                  : " + String(FDRS_MQTT_PORT));
-#endif //MQTT_PORT
-
-#ifdef FDRS_MQTT_AUTH
-	DBG("MQTT AUTHENTIFICATION CONFIG:");
-	
-//GLOBAL_MQTT_AUTH
-#if defined(MQTT_USER)
-	DBG("MQTT username used from MQTT_USER        : " + String(FDRS_MQTT_USER));
-#elif defined (GLOBAL_MQTT_USER)
-	DBG("MQTT username used from GLOBAL_MQTT_USER : " + String(FDRS_MQTT_USER));
-#else 
-	DBG("NO MQTT username defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //MQTT_USER
-
-#if defined(MQTT_PASS)
-	DBG("MQTT password used from MQTT_PASS        : " + String(FDRS_MQTT_PASS));
-#elif defined (GLOBAL_MQTT_PASS)
-	DBG("MQTT password used from GLOBAL_MQTT_PASS : " + String(FDRS_MQTT_PASS));
-#else 
-	DBG("NO MQTT password defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //MQTT_PASS
-
-#endif //FDRS_MQTT_AUTH
-	DBG("----------------------------------------------------");
-
-#endif //USE_WIFI
-
-#ifdef USE_LORA
-	
-	DBG("----------------------------------------------------");
-	DBG("SENSOR LORA CONFIG:");
-#if defined(LORA_BAND)
-	DBG("LoRa Band used from LORA_BAND       : " + String(FDRS_BAND));
-#elif defined (GLOBAL_LORA_BAND)
-	DBG("LoRa Band used from GLOBAL_LORA_BAND: " + String(FDRS_BAND));
-#else 
-	DBG("NO LORA-BAND defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //LORA-BAND
-
-#if defined(LORA_SF)
-	DBG("LoRa SF used from LORA_SF           : " + String(FDRS_SF));
-#elif defined (GLOBAL_LORA_SF)
-	DBG("LoRa SF used from GLOBAL_LORA_SF    : " + String(FDRS_SF));
-#else 
-//	ASSERT("NO LORA-SF defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	DBG("NO LORA-SF defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //LORA-BAND
-#endif //USE_LORA
-	DBG("----------------------------------------------------");
-	DBG("");
-}
-
-
 
 // Set ESP-NOW send and receive callbacks for either ESP8266 or ESP32
 #if defined(ESP8266)
@@ -843,12 +750,8 @@ void begin_lora() {
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);
-#ifdef DEBUG_NODE_CONFIG
-  debugConfig();
-#else
   DBG("LoRa Band: " + String(FDRS_BAND));
   DBG("LoRa SF  : " + String(FDRS_SF));
-#endif //DEBUG_NODE_CONFIG
 #endif // USE_LORA
 }
 

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -183,7 +183,6 @@ void sleepFDRS(int sleep_time) {
 #ifdef ESP32
   esp_sleep_enable_timer_wakeup(sleep_time * 1000000);
   esp_deep_sleep_start();
-  
 #endif
 #ifdef ESP8266
   ESP.deepSleep(sleep_time * 1000000);

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -18,7 +18,7 @@
 #endif
 
 // enable to get detailed info from where single configuration macros have been taken
-//#define DEBUG_NODE_CONFIG
+#define DEBUG_NODE_CONFIG
 
 #ifdef USE_LORA
 
@@ -50,6 +50,10 @@
 
 #define MAC_PREFIX  0xAA, 0xBB, 0xCC, 0xDD, 0xEE  // Should only be changed if implementing multiple FDRS systems.
 
+#ifdef DEBUG_NODE_CONFIG
+#include "fdrs_checkConfig.h"
+#endif
+
 typedef struct __attribute__((packed)) DataReading {
   float d;
   uint16_t id;
@@ -67,39 +71,12 @@ DataReading fdrsData[espnow_size];
 uint8_t data_count = 0;
 
 
-void debugConfig() {
-#ifdef USE_LORA
-	
-	DBG("----------------------------------------------------");
-	DBG("SENSOR LORA CONFIG");
-	DBG("----------------------------------------------------");
-#if defined(LORA_BAND)
-	DBG("LoRa Band used from LORA_BAND       : " + String(FDRS_BAND));
-#elif defined (GLOBAL_LORA_BAND)
-	DBG("LoRa Band used from GLOBAL_LORA_BAND: " + String(FDRS_BAND));
-#else 
-	DBG("NO LORA-BAND defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //LORA-BAND
-
-#if defined(LORA_SF)
-	DBG("LoRa SF used from LORA_SF           : " + String(FDRS_SF));
-#elif defined (GLOBAL_LORA_SF)
-	DBG("LoRa SF used from GLOBAL_LORA_SF    : " + String(FDRS_SF));
-#else 
-//	ASSERT("NO LORA-SF defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	DBG("NO LORA-SF defined! Please define in fdrs_globals.h (recommended) or in fdrs_sensor_config.h");
-	//exit(0);
-#endif //LORA-BAND
-	DBG("----------------------------------------------------");
-	DBG("");
-#endif //USE_LORA
-}
-
-
 void beginFDRS() {
 #ifdef FDRS_DEBUG
   Serial.begin(115200);
+  // find out the reset reason
+  esp_reset_reason_t resetReason;
+  resetReason = esp_reset_reason();
 #endif
   DBG("FDRS Sensor ID " + String(READING_ID) + " initializing...");
   DBG(" Gateway: " + String (GTWY_MAC, HEX));
@@ -137,7 +114,7 @@ void beginFDRS() {
   }
 #endif
   DBG(" ESP-NOW Initialized.");
-#endif
+#endif //USE_ESPNOW
 #ifdef USE_LORA
   DBG("Initializing LoRa!");
 #ifdef ESP32
@@ -150,13 +127,16 @@ void beginFDRS() {
   }
   LoRa.setSpreadingFactor(FDRS_SF);
   DBG(" LoRa Initialized.");
-#ifdef DEBUG_NODE_CONFIG
-  debugConfig();
-#else
+
   DBG("LoRa Band: " + String(FDRS_BAND));
   DBG("LoRa SF  : " + String(FDRS_SF));
-#endif //DEBUG_NODE_CONFIG
 #endif // USE_LORA
+#ifdef DEBUG_NODE_CONFIG
+  if (resetReason != ESP_RST_DEEPSLEEP) {
+    checkConfig();
+  }
+#endif //DEBUG_NODE_CONFIG
+
 }
 
 void transmitLoRa(uint8_t* mac, DataReading * packet, uint8_t len) {
@@ -203,6 +183,7 @@ void sleepFDRS(int sleep_time) {
 #ifdef ESP32
   esp_sleep_enable_timer_wakeup(sleep_time * 1000000);
   esp_deep_sleep_start();
+  
 #endif
 #ifdef ESP8266
   ESP.deepSleep(sleep_time * 1000000);


### PR DESCRIPTION
- moved configuration checkup to external file to make sensor and gateway files more tidy (and smaller).
- for sensors the config now only is shown if the sensor does NOT return from Deep Sleep. For example when pressing the reset button or after a crash.
- for gateways the configuration is shown once and also can be forced to be shown with a reset. Code should work for ESP32 and ESP8266 - have only tested it with ESP32.
- fixed issue in fdrs_functions.h - if MQTT_AUTH was enabled but WIFI disabled, the compile crashed.

I needed to define a USE_ESPNOW in fdrs_gateway_config.h to make things easier. Actually this is needed anyway as it is not obligatory for a gateway to offer ESP-Now support. 
As the gateway code does not offer a central starting point like beginFDRS() as the sensor does, I had to implement the config check in the .ino file. This has been done only in 4_UART_Gateway so far.
