### PR TITLE
Prefix debug messages with millis() timestamp

### DIFF
--- a/FDRS_Gateway/fdrs_functions.h
+++ b/FDRS_Gateway/fdrs_functions.h
@@ -20,10 +20,17 @@ enum {
   event_lora2
 };
 
+enum crcResult{
+  CRC_NULL,
+  CRC_OK,
+  CRC_BAD,
+} returnCRC = CRC_NULL;
+
 enum {
   cmd_clear,
   cmd_ping,
   cmd_add,
+  cmd_ack
 };
 
 #ifdef FDRS_DEBUG
@@ -100,9 +107,13 @@ uint8_t ESPNOW2[] =       {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 #endif
 
 #ifdef USE_LORA
-uint8_t LoRa1[] =         {mac_prefix[3], mac_prefix[4], LORA1_PEER};
-uint8_t LoRa2[] =         {mac_prefix[3], mac_prefix[4], LORA2_PEER};
-//uint8_t LoRaAddress[] = {0x42, 0x00};
+uint16_t LoRa1 =         ((mac_prefix[4] << 8) | LORA1_PEER);  // Use 2 bytes for LoRa addressing instead of previous 3 bytes
+uint16_t LoRa2 =         ((mac_prefix[4] << 8) | LORA2_PEER);
+//uint16_t LoRaAddress = 0x4200;
+uint16_t loraGwAddress = ((selfAddress[4] << 8) | selfAddress[5]); // last 2 bytes of gateway address
+uint16_t loraBroadcast = 0xFFFF;
+unsigned long receivedLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size
+unsigned long ackOkLoRaMsg = 0;     // Number of total LoRa packets with valid CRC
 #endif
 
 #if defined (USE_SD_LOG) || defined (USE_FS_LOG)
@@ -317,31 +328,138 @@ void mqtt_publish(const char* payload) {
 #endif
 }
 
+void printLoraPacket(uint8_t* p,int size) {
+  printf("Printing packet of size %d.",size);
+  for(int i = 0; i < size; i++ ) {
+    if(i % 2 == 0) printf("\n%02d: ", i);
+    printf("%02X ", p[i]);
+  }
+  printf("\n");
+}
+
 void getLoRa() {
 #ifdef USE_LORA
   int packetSize = LoRa.parsePacket();
-  if (packetSize) {
+  if((packetSize - 6) % sizeof(DataReading) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of DataReading
     uint8_t packet[packetSize];
-    uint8_t incLORAMAC[2];
+    uint16_t packetCRC = 0x0000; // CRC Extracted from received LoRa packet
+    uint16_t calcCRC = 0x0000; // CRC calculated from received LoRa packet
+    uint16_t sourceMAC = 0x0000;
+    uint16_t destMAC = 0x0000;
+  
     LoRa.readBytes((uint8_t *)&packet, packetSize);
-    ln = (packetSize - 5) / sizeof(DataReading);
-    DBG("Incoming LoRa.");
-    if (memcmp(&packet, &selfAddress[3], 3) == 0) {   //Check if addressed to this device
-      memcpy(&incLORAMAC, &packet[3], 2);             //Split off address portion of packet
-      memcpy(&theData, &packet[5], packetSize - 5);   //Split off data portion of packet
-      if (memcmp(&incLORAMAC, &LoRa1, 2) == 0) {      //Check if it is from a registered sender
+    ln = (packetSize - 6) / sizeof(DataReading);
+    
+    destMAC = (packet[0] << 8) | packet[1];
+    sourceMAC = (packet[2] << 8) | packet[3];
+    packetCRC = ((packet[packetSize - 2] << 8) | packet[packetSize - 1]);
+    //DBG("Packet Address: 0x" + String(packet[0],16) + String(packet[1],16) + " Self Address: 0x" + String(selfAddress[4],16) + String(selfAddress[5],16));
+    if (destMAC == (selfAddress[4] << 8 | selfAddress[5])) {   //Check if addressed to this device (2 bytes, bytes 1 and 2)
+      //printLoraPacket(packet,sizeof(packet));
+      memcpy(&theData, &packet[4], packetSize - 6);   //Split off data portion of packet (N - 6 bytes (6 bytes for headers and CRC))
+      if(receivedLoRaMsg != 0){  // Avoid divide by 0
+        DBG("Incoming LoRa. Size: " + String(packetSize) + " Bytes, RSSI: " + String(LoRa.packetRssi()) + "dBi, SNR: " + String(LoRa.packetSnr()) + "dB, PacketCRC: 0x" + String(packetCRC,16) + ", Total LoRa received: " + String(receivedLoRaMsg) + ", CRC Ok Pct " + String((float)ackOkLoRaMsg/receivedLoRaMsg*100) + "%");
+      }
+      else {
+        DBG("Incoming LoRa. Size: " + String(packetSize) + " Bytes, RSSI: " + String(LoRa.packetRssi()) + "dBi, SNR: " + String(LoRa.packetSnr()) + "dB, PacketCRC: 0x" + String(packetCRC,16) + ", Total LoRa received: " + String(receivedLoRaMsg));
+      }
+      receivedLoRaMsg++;
+      // Evaluate CRC
+      if(packetCRC == 0xFFFF) { // CRC is set that destination does not want ACK so do not send.
+        DBG("Sensor address 0x" + String(sourceMAC,16) + "(hex) does not want ACK");
+        ackOkLoRaMsg++;
+      }
+      else { // Calculate expected CRC and compare to what is in the packet
+        for(int i = 0; i < (packetSize - 2); i++) { // Last 2 bytes of packet are the CRC so do not include them in calculation
+          //printf("CRC: %02X : %d\n",calcCRC, i);
+          calcCRC = crc16_update(calcCRC, packet[i]);
+        }
+        if(calcCRC == packetCRC) {
+          SystemPacket ACK = { .cmd = cmd_ack, .param = CRC_OK };
+          DBG("CRC Match, sending ACK packet to sensor 0x" + String(sourceMAC,16) + "(hex)");
+          transmitLoRa(&sourceMAC, &ACK, 1);  // Send ACK back to source
+          ackOkLoRaMsg++;
+        }
+        else {
+          SystemPacket NAK = { .cmd = cmd_ack, .param = CRC_BAD };
+          // Send NAK packet to sensor
+          DBG("CRC Mismatch! Packet CRC is 0x" + String(packetCRC,16) + ", Calculated CRC is 0x" + String(calcCRC,16) + " Sending NAK packet to sensor 0x" + String(sourceMAC,16) + "(hex)");
+          transmitLoRa(&sourceMAC, &NAK, 1); // CRC did not match so send NAK to source
+          newData = event_clear;  // do not process data as data may be corrupt
+          return;  // Exit function and do not update newData to send invalid data further on
+        }
+      }
+      if (memcmp(&sourceMAC, &LoRa1, 2) == 0) {      //Check if it is from a registered sender
         newData = event_lora1;
         return;
       }
-      if (memcmp(&incLORAMAC, &LoRa2, 2) == 0) {
+      if (memcmp(&sourceMAC, &LoRa2, 2) == 0) {
         newData = event_lora2;
         return;
       }
       newData = event_lorag;
     }
+    else {
+      DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received from address 0x" + String(sourceMAC,16) + " destined for node address 0x" + String(destMAC,16));
+    }
+  }
+  else {
+    if(packetSize != 0) {
+      DBG("Incoming LoRa packet of " + String(packetSize) + " not processed.");
+    }
   }
 #endif
 }
+
+#ifdef USE_LORA
+void transmitLoRa(uint16_t* destMac, DataReading * packet, uint8_t len) {
+  uint16_t calcCRC = 0x0000;
+
+  uint8_t pkt[6 + (len * sizeof(DataReading))];
+  
+  pkt[0] = (*destMac >> 8);       // high byte of destination MAC
+  pkt[1] = (*destMac & 0x00FF);   // low byte of destination MAC
+  pkt[2] = selfAddress[4];    // high byte of source MAC (ourselves)
+  pkt[3] = selfAddress[5];    // low byte of source MAC
+  memcpy(&pkt[4], packet, len * sizeof(DataReading));   // copy data portion of packet
+  for(int i = 0; i < (sizeof(pkt) - 2); i++) {  // Last 2 bytes are CRC so do not include them in the calculation itself
+    //printf("CRC: %02X : %d\n",calcCRC, i);
+    calcCRC = crc16_update(calcCRC, pkt[i]);
+  }
+  pkt[(len * sizeof(DataReading) + 4)] = (calcCRC >> 8); // Append calculated CRC to the last 2 bytes of the packet
+  pkt[(len * sizeof(DataReading) + 5)] = (calcCRC & 0x00FF);
+  DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC,16) + " to LoRa MAC 0x" + String(*destMac,16));
+  //printLoraPacket(pkt,sizeof(pkt));
+  LoRa.beginPacket();
+  LoRa.write((uint8_t*)&pkt, sizeof(pkt));
+  LoRa.endPacket();
+  }
+#endif
+
+#ifdef USE_LORA
+void transmitLoRa(uint16_t* destMac, SystemPacket * packet, uint8_t len) {
+  uint16_t calcCRC = 0x0000;
+
+  uint8_t pkt[6 + (len * sizeof(SystemPacket))];
+  
+  pkt[0] = (*destMac >> 8);       // high byte of destination MAC
+  pkt[1] = (*destMac & 0x00FF);   // low byte of destination MAC
+  pkt[2] = selfAddress[4];    // high byte of source MAC (ourselves)
+  pkt[3] = selfAddress[5];    // low byte of source MAC
+  memcpy(&pkt[4], packet, len * sizeof(SystemPacket));   // copy data portion of packet
+  for(int i = 0; i < (sizeof(pkt) - 2); i++) {  // Last 2 bytes are CRC so do not include them in the calculation itself
+    //printf("CRC: %02X : %d\n",calcCRC, i);
+    calcCRC = crc16_update(calcCRC, pkt[i]);
+}
+  pkt[(len * sizeof(SystemPacket) + 4)] = (calcCRC >> 8); // Append calculated CRC to the last 2 bytes of the packet
+  pkt[(len * sizeof(SystemPacket) + 5)] = (calcCRC & 0x00FF);
+  DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC,16) + " to LoRa MAC 0x" + String(*destMac,16));
+  //printLoraPacket(pkt,sizeof(pkt));
+  LoRa.beginPacket();
+  LoRa.write((uint8_t*)&pkt, sizeof(pkt));
+  LoRa.endPacket();
+}
+#endif
 
 void sendESPNOW(uint8_t address) {
   DBG("Sending ESP-NOW.");
@@ -526,19 +644,6 @@ void releaseESPNOW(uint8_t interface) {
       }
   }
 }
-#ifdef USE_LORA
-void transmitLoRa(uint8_t* mac, DataReading * packet, uint8_t len) {
-  DBG("Transmitting LoRa.");
-
-  uint8_t pkt[5 + (len * sizeof(DataReading))];
-  memcpy(&pkt, mac, 3);
-  memcpy(&pkt[3], &selfAddress[4], 2);
-  memcpy(&pkt[5], packet, len * sizeof(DataReading));
-  LoRa.beginPacket();
-  LoRa.write((uint8_t*)&pkt, sizeof(pkt));
-  LoRa.endPacket();
-}
-#endif
 
 void releaseLoRa(uint8_t interface) {
 #ifdef USE_LORA
@@ -552,12 +657,12 @@ void releaseLoRa(uint8_t interface) {
         for (int i = 0; i < lenLORAG; i++) {
           if ( j > lora_size) {
             j = 0;
-            transmitLoRa(broadcast_mac, thePacket, j);
+            transmitLoRa(&loraBroadcast, thePacket, j);
           }
           thePacket[j] = LORAGbuffer[i];
           j++;
         }
-        transmitLoRa(broadcast_mac, thePacket, j);
+        transmitLoRa(&loraBroadcast, thePacket, j);
         lenLORAG = 0;
 
         break;
@@ -569,12 +674,12 @@ void releaseLoRa(uint8_t interface) {
         for (int i = 0; i < lenLORA1; i++) {
           if ( j > lora_size) {
             j = 0;
-            transmitLoRa(LoRa1, thePacket, j);
+            transmitLoRa(&LoRa1, thePacket, j);
           }
           thePacket[j] = LORA1buffer[i];
           j++;
         }
-        transmitLoRa(LoRa1, thePacket, j);
+        transmitLoRa(&LoRa1, thePacket, j);
         lenLORA1 = 0;
         break;
       }
@@ -585,18 +690,18 @@ void releaseLoRa(uint8_t interface) {
         for (int i = 0; i < lenLORA2; i++) {
           if ( j > lora_size) {
             j = 0;
-            transmitLoRa(LoRa2, thePacket, j);
+            transmitLoRa(&LoRa2, thePacket, j);
           }
           thePacket[j] = LORA2buffer[i];
           j++;
         }
-        transmitLoRa(LoRa2, thePacket, j);
+        transmitLoRa(&LoRa2, thePacket, j);
         lenLORA2 = 0;
 
         break;
       }
   }
-#endif //USE_LORA
+#endif
 }
 void releaseSerial() {
   DBG("Releasing Serial.");
@@ -759,6 +864,32 @@ void handleCommands() {
 }
 
 
+// CRC16 from https://github.com/4-20ma/ModbusMaster/blob/3a05ff87677a9bdd8e027d6906dc05ca15ca8ade/src/util/crc16.h#L71
 
+/** @ingroup util_crc16
+    Processor-independent CRC-16 calculation.
+    Polynomial: x^16 + x^15 + x^2 + 1 (0xA001)<br>
+    Initial value: 0xFFFF
+    This CRC is normally used in disk-drive controllers.
+    @param uint16_t crc (0x0000..0xFFFF)
+    @param uint8_t a (0x00..0xFF)
+    @return calculated CRC (0x0000..0xFFFF)
+*/
+
+static uint16_t crc16_update(uint16_t crc, uint8_t a)
+{
+  int i;
+
+  crc ^= a;
+  for (i = 0; i < 8; ++i)
+  {
+    if (crc & 1)
+      crc = (crc >> 1) ^ 0xA001;
+    else
+      crc = (crc >> 1);
+  }
+
+  return crc;
+}
 
 #endif //__FDRS_FUNCTIONS_H__

--- a/FDRS_Gateway/fdrs_functions.h
+++ b/FDRS_Gateway/fdrs_functions.h
@@ -36,7 +36,7 @@ enum {
 };
 
 #ifdef FDRS_DEBUG
-#define DBG(a) (Serial.println(a))
+#define DBG(a) (Serial.println(millis()) + ": " + a))
 #else
 #define DBG(a)
 #endif

--- a/FDRS_Gateway/fdrs_gateway_config.h
+++ b/FDRS_Gateway/fdrs_gateway_config.h
@@ -57,8 +57,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_NOACK_CRC 0xFFFF
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/FDRS_Gateway/fdrs_gateway_config.h
+++ b/FDRS_Gateway/fdrs_gateway_config.h
@@ -59,7 +59,6 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_NOACK_CRC 0xFFFF
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -293,13 +293,12 @@ void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
   pkt[2] = (LoRaAddress >> 8);
   pkt[3] = (LoRaAddress & 0x00FF);
   memcpy(&pkt[4], packet, len * sizeof(DataReading));
-#ifdef LORA_ACK
   for(int i = 0; i < (sizeof(pkt) - 2); i++) {  // Last 2 bytes are CRC so do not include them in the calculation itself
     //printf("CRC: %02X : %d\n",calcCRC, i);
     calcCRC = crc16_update(calcCRC, pkt[i]);
   }
-#else
-  calcCRC = LORA_NOACK_CRC;
+#ifndef LORA_ACK
+  calcCRC = crc16_update(calcCRC, 0xA1); // Recalculate CRC for No ACK
 #endif    // LORA_ACK
   pkt[len * sizeof(DataReading) + 4] = (calcCRC >> 8);
   pkt[len * sizeof(DataReading) + 5] = (calcCRC & 0x00FF);

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -57,10 +57,18 @@ typedef struct __attribute__((packed)) DataReading {
 
 } DataReading;
 
+
+enum crcResult{
+  CRC_NULL,
+  CRC_OK,
+  CRC_BAD,
+} returnCRC;
+
 enum {
   cmd_clear,
   cmd_ping,
   cmd_add,
+  cmd_ack,
 };
 
 typedef struct __attribute__((packed)) SystemPacket {
@@ -70,8 +78,11 @@ typedef struct __attribute__((packed)) SystemPacket {
 
 const uint16_t espnow_size = 250 / sizeof(DataReading);
 uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
-uint8_t gtwyAddress[] = {gatewayAddress[3], gatewayAddress[4], GTWY_MAC};
-uint8_t LoRaAddress[] = {0x42, 0x00};
+uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
+uint16_t LoRaAddress = 0x4200;
+unsigned long transmitLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size
+unsigned long msgOkLoRa = 0;     // Number of total LoRa packets with valid CRC
+
 
 uint32_t wait_time = 0;
 DataReading fdrsData[espnow_size];
@@ -196,16 +207,143 @@ void beginFDRS() {
 #endif // USE_LORA
 }
 
-void transmitLoRa(uint8_t* mac, DataReading * packet, uint8_t len) {
+//  USED to get ACKs from LoRa gateway at this point.  May be used in the future to get other data
+// Return type is crcResult struct - CRC_OK, CRC_BAD, CRC_NULL.  CRC_NULL used for non-ack data
+crcResult getLoRa() {
 #ifdef USE_LORA
-  uint8_t pkt[5 + (len * sizeof(DataReading))];
-  memcpy(&pkt, mac, 3);  //
-  memcpy(&pkt[3], &LoRaAddress, 2);
-  memcpy(&pkt[5], packet, len * sizeof(DataReading));
+  int packetSize = LoRa.parsePacket();
+  if ((packetSize - 6) % sizeof(SystemPacket) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of SystemPacket
+    uint8_t packet[packetSize];
+    uint16_t sourceMAC = 0x0000;
+    uint16_t destMAC = 0x0000;
+    uint16_t packetCRC = 0x0000; // CRC Extracted from received LoRa packet
+    uint16_t calcCRC = 0x0000; // CRC calculated from received LoRa packet
+    uint ln = (packetSize - 6) / sizeof(SystemPacket);
+    SystemPacket receiveData[ln];
+  
+    LoRa.readBytes((uint8_t *)&packet, packetSize);
+    
+    destMAC = (packet[0] << 8) | packet[1];
+    sourceMAC = (packet[2] << 8) | packet[3];
+    packetCRC = ((packet[packetSize - 2] << 8) | packet[packetSize - 1]);
+    DBG("Incoming LoRa. Size: " + String(packetSize) + " Bytes, RSSI: " + String(LoRa.packetRssi()) + "dBi, SNR: " + String(LoRa.packetSnr()) + "dB, PacketCRC: 0x" + String(packetCRC,16));
+    if (destMAC == LoRaAddress) {
+      //printLoraPacket(packet,sizeof(packet));
+      memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+      if(ln == 1 && receiveData[0].cmd == cmd_ack) { // We have received an ACK packet
+        if(packetCRC == 0xFFFF) {
+          DBG("ACK Received - address 0x" + String(sourceMAC,16) + "(hex) does not want ACKs");
+          return CRC_OK;
+        }
+        else {
+          for(int i = 0; i < (packetSize - 2); i++) { // Last 2 bytes of packet are the CRC so do not include them in calculation
+            //printf("CRC: %02X : %d\n",calcCRC, i);
+            calcCRC = crc16_update(calcCRC, packet[i]);
+          }
+          if(calcCRC == packetCRC) {
+            DBG("ACK Received - CRC Match");
+            return CRC_OK;
+          }
+          else {
+            DBG("ACK Received CRC Mismatch! Packet CRC is 0x" + String(packetCRC,16) + ", Calculated CRC is 0x" + String(calcCRC,16));
+            return CRC_BAD;
+          }
+        }
+      }
+      else{ // data we have received is not of type ACK_T.  How we handle is future enhancement.
+        DBG("Received some LoRa SystemPacket data that is not of type ACK.  To be handled in future enhancement.");
+        DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+        return CRC_NULL;
+      }
+    }
+    else if((packetSize - 6) % sizeof(DataReading) == 0) {  // packet size should be 6 bytes plus multiple of size of DataReading)
+      DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received, with DataReading data to be processed.");
+      return CRC_NULL;
+    }
+    else {
+      DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received, not destined to our address.");
+      return CRC_NULL;
+    }
+  }
+  else { 
+    if(packetSize != 0) {
+      DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received");
+    }
+  }
+return CRC_NULL;
+#endif
+}
+
+void printLoraPacket(uint8_t* p,int size) {
+  printf("Printing packet of size %d.",size);
+  for(int i = 0; i < size; i++ ) {
+    if(i % 2 == 0) printf("\n%02d: ", i);
+    printf("%02X ", p[i]);
+  }
+  printf("\n");
+}
+
+void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
+#ifdef USE_LORA
+  uint8_t pkt[6 + (len * sizeof(DataReading))];
+  uint16_t calcCRC = 0x0000;
+
+  pkt[0] = (*destMAC >> 8);
+  pkt[1] = (*destMAC & 0x00FF);
+  pkt[2] = (LoRaAddress >> 8);
+  pkt[3] = (LoRaAddress & 0x00FF);
+  memcpy(&pkt[4], packet, len * sizeof(DataReading));
+#ifdef LORA_ACK
+  for(int i = 0; i < (sizeof(pkt) - 2); i++) {  // Last 2 bytes are CRC so do not include them in the calculation itself
+    //printf("CRC: %02X : %d\n",calcCRC, i);
+    calcCRC = crc16_update(calcCRC, pkt[i]);
+  }
+#else
+  calcCRC = LORA_NOACK_CRC;
+#endif    // LORA_ACK
+  pkt[len * sizeof(DataReading) + 4] = (calcCRC >> 8);
+  pkt[len * sizeof(DataReading) + 5] = (calcCRC & 0x00FF);
+#ifdef LORA_ACK  // Wait for ACK
+  int retries = LORA_RETRIES + 1;
+  while(retries != 0) {
+    if(transmitLoRaMsg != 0)
+      DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC,16) + " to gateway 0x" + String(*destMAC,16) + ". Retries remaining: " + String(retries - 1) + ", CRC OK " + String((float)msgOkLoRa/transmitLoRaMsg*100) + "%");
+    else 
+      DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC,16) + " to gateway 0x" + String(*destMAC,16) + ". Retries remaining: " + String(retries - 1));
+    //printLoraPacket(pkt,sizeof(pkt));
+    LoRa.beginPacket();
+    LoRa.write((uint8_t*)&pkt, sizeof(pkt));
+    LoRa.endPacket();
+    transmitLoRaMsg++;
+    unsigned long loraAckTimeout = millis() + LORA_ACK_TIMEOUT; 
+    retries--;
+    delay(10);
+    while(returnCRC == CRC_NULL && (millis() < loraAckTimeout)) {
+      returnCRC = getLoRa();
+    }
+    if(returnCRC == CRC_OK) {
+      //DBG("LoRa ACK Received! CRC OK");
+      msgOkLoRa++;
+      return;  // we're done
+    }
+    else if(returnCRC == CRC_BAD) {
+      //DBG("LoRa ACK Received! CRC BAD");
+      // Resend original packet again if retries are available
+    }
+    else {
+      DBG("LoRa Timeout waiting for ACK!");
+      // resend original packet again if retries are available
+    }
+  }
+#else   // Send and do not wait for ACK reply
+  DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC,16) + " to gateway 0x" + String(*destMAC,16));
+  //printLoraPacket(pkt,sizeof(pkt));
   LoRa.beginPacket();
   LoRa.write((uint8_t*)&pkt, sizeof(pkt));
   LoRa.endPacket();
-#endif
+  transmitLoRaMsg++;
+#endif    // LORA_ACK
+#endif    // USE_LORA
 }
 
 void sendFDRS() {
@@ -216,10 +354,10 @@ void sendFDRS() {
   DBG(" ESP-NOW sent.");
 #endif
 #ifdef USE_LORA
-  transmitLoRa(gtwyAddress, fdrsData, data_count);
-  DBG(" LoRa sent.");
+  transmitLoRa(&gtwyAddress, fdrsData, data_count);
 #endif
   data_count = 0;
+  returnCRC = CRC_NULL;
 }
 
 void loadFDRS(float d, uint8_t t) {
@@ -270,4 +408,32 @@ void pingFDRS(int timeout) {
   //transmitLoRa(gtwyAddress, sys_packet, data_count); // TODO: Make this congruent to esp_now_send()
   DBG(" LoRa ping not sent because it isn't implemented.");
 #endif
+}
+
+// CRC16 from https://github.com/4-20ma/ModbusMaster/blob/3a05ff87677a9bdd8e027d6906dc05ca15ca8ade/src/util/crc16.h#L71
+
+/** @ingroup util_crc16
+    Processor-independent CRC-16 calculation.
+    Polynomial: x^16 + x^15 + x^2 + 1 (0xA001)<br>
+    Initial value: 0xFFFF
+    This CRC is normally used in disk-drive controllers.
+    @param uint16_t crc (0x0000..0xFFFF)
+    @param uint8_t a (0x00..0xFF)
+    @return calculated CRC (0x0000..0xFFFF)
+*/
+
+static uint16_t crc16_update(uint16_t crc, uint8_t a)
+{
+  int i;
+
+  crc ^= a;
+  for (i = 0; i < 8; ++i)
+  {
+    if (crc & 1)
+      crc = (crc >> 1) ^ 0xA001;
+    else
+      crc = (crc >> 1);
+  }
+
+  return crc;
 }

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -43,7 +43,7 @@
 #endif //USE_LORA
 
 #ifdef FDRS_DEBUG
-#define DBG(a) (Serial.println(a))
+#define DBG(a) (Serial.println(millis()) + ": " + a))
 #else
 #define DBG(a)
 #endif

--- a/FDRS_Sensor/fdrs_sensor_config.h
+++ b/FDRS_Sensor/fdrs_sensor_config.h
@@ -26,5 +26,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/FDRS_Sensor/fdrs_sensor_config.h
+++ b/FDRS_Sensor/fdrs_sensor_config.h
@@ -5,7 +5,7 @@
 #include <fdrs_globals.h>
 
 #define READING_ID    1   //Unique ID for this sensor
-#define GTWY_MAC      0x04 //Address of the nearest gateway
+#define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW
 //#define USE_LORA

--- a/FDRS_Sensor/fdrs_sensor_config.h
+++ b/FDRS_Sensor/fdrs_sensor_config.h
@@ -28,7 +28,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/FDRS_Sensor/fdrs_sensor_config.h
+++ b/FDRS_Sensor/fdrs_sensor_config.h
@@ -29,6 +29,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/1_LoRa_Sensor/fdrs_sensor_config.h
+++ b/examples/1_LoRa_Sensor/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/1_LoRa_Sensor/fdrs_sensor_config.h
+++ b/examples/1_LoRa_Sensor/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/1_LoRa_Sensor/fdrs_sensor_config.h
+++ b/examples/1_LoRa_Sensor/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
+++ b/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
+++ b/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
+++ b/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/3_ESPNOW_Gateway/fdrs_gateway_config.h
+++ b/examples/3_ESPNOW_Gateway/fdrs_gateway_config.h
@@ -57,8 +57,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_NOACK_CRC 0xFFFF
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/examples/3_ESPNOW_Gateway/fdrs_gateway_config.h
+++ b/examples/3_ESPNOW_Gateway/fdrs_gateway_config.h
@@ -59,7 +59,6 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_NOACK_CRC 0xFFFF
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/examples/4_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/4_UART_Gateway/fdrs_gateway_config.h
@@ -57,8 +57,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_NOACK_CRC 0xFFFF
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/examples/4_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/4_UART_Gateway/fdrs_gateway_config.h
@@ -59,7 +59,6 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_NOACK_CRC 0xFFFF
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/examples/5_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/5_MQTT_Gateway/fdrs_gateway_config.h
@@ -57,8 +57,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_NOACK_CRC 0xFFFF
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/examples/5_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/5_MQTT_Gateway/fdrs_gateway_config.h
@@ -59,7 +59,6 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_NOACK_CRC 0xFFFF
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/examples/ESPNOW_Stress_Test/fdrs_sensor_config.h
+++ b/examples/ESPNOW_Stress_Test/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/ESPNOW_Stress_Test/fdrs_sensor_config.h
+++ b/examples/ESPNOW_Stress_Test/fdrs_sensor_config.h
@@ -27,7 +27,6 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
@@ -28,6 +28,5 @@
 #define LORA_BAND 915E6
 #define LORA_SF 7
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
@@ -25,5 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-//#define LORA_BAND 915E6
-//#define LORA_SF 7
+#define LORA_BAND 915E6
+#define LORA_SF 7
+#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+#define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
+#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
@@ -27,7 +27,7 @@
 //915E6 for North America
 #define LORA_BAND 915E6
 #define LORA_SF 7
-#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
+//#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
 #define LORA_NOACK_CRC 0xFFFF  // CRC value to be used when ACKs are disabled to tell gateway we do not want ACK
 #define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
 #define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Universal_Gateway_beta/UG_ESPNOW_2_MQTT/fdrs_gateway.h
+++ b/examples/Universal_Gateway_beta/UG_ESPNOW_2_MQTT/fdrs_gateway.h
@@ -28,7 +28,7 @@
 #define FDRS_DEBUG
 
 #ifdef FDRS_DEBUG
-#define DBG(a) (Serial.println(a))
+#define DBG(a) (Serial.println(millis()) + ": " + a))
 #else
 #define DBG(a)
 #endif

--- a/examples/Universal_Gateway_beta/fdrs_gateway.h
+++ b/examples/Universal_Gateway_beta/fdrs_gateway.h
@@ -28,7 +28,7 @@
 #define FDRS_DEBUG
 
 #ifdef FDRS_DEBUG
-#define DBG(a) (Serial.println(a))
+#define DBG(a) (Serial.println(millis()) + ": " + a))
 #else
 #define DBG(a)
 #endif

--- a/examples/Universal_Sensor_beta/fdrs_sensor.h
+++ b/examples/Universal_Sensor_beta/fdrs_sensor.h
@@ -49,7 +49,7 @@
 #endif //FDRS_GLOBAL_LORA
 
 #ifdef FDRS_DEBUG
-#define DBG(a) (Serial.println(a))
+#define DBG(a) (Serial.println(millis()) + ": " + a))
 #else
 #define DBG(a)
 #endif

--- a/fdrs_functions.h
+++ b/fdrs_functions.h
@@ -34,7 +34,7 @@ enum {
 };
 
 #ifdef FDRS_DEBUG
-#define DBG(a) (Serial.println(a))
+#define DBG(a) (Serial.println(millis()) + ": " + a))
 #else
 #define DBG(a)
 #endif

--- a/fdrs_functions.h
+++ b/fdrs_functions.h
@@ -523,30 +523,29 @@ void getLoRa() {
       }
       receivedLoRaMsg++;
       // Evaluate CRC
-      if(packetCRC == 0xFFFF) { // CRC is set that destination does not want ACK so do not send.
+      for(int i = 0; i < (packetSize - 2); i++) { // Last 2 bytes of packet are the CRC so do not include them in calculation
+        //printf("CRC: %02X : %d\n",calcCRC, i);
+        calcCRC = crc16_update(calcCRC, packet[i]);
+      }
+      if(calcCRC == packetCRC) {
+        SystemPacket ACK = { .cmd = cmd_ack, .param = CRC_OK };
+        DBG("CRC Match, sending ACK packet to sensor 0x" + String(sourceMAC,16) + "(hex)");
+        transmitLoRa(&sourceMAC, &ACK, 1);  // Send ACK back to source
+        ackOkLoRaMsg++;
+      }
+      else if(packetCRC == crc16_update(calcCRC,0xA1)) { // Sender does not want ACK and CRC is valid
         DBG("Sensor address 0x" + String(sourceMAC,16) + "(hex) does not want ACK");
         ackOkLoRaMsg++;
       }
-      else { // Calculate expected CRC and compare to what is in the packet
-        for(int i = 0; i < (packetSize - 2); i++) { // Last 2 bytes of packet are the CRC so do not include them in calculation
-          //printf("CRC: %02X : %d\n",calcCRC, i);
-          calcCRC = crc16_update(calcCRC, packet[i]);
-        }
-        if(calcCRC == packetCRC) {
-          SystemPacket ACK = { .cmd = cmd_ack, .param = CRC_OK };
-          DBG("CRC Match, sending ACK packet to sensor 0x" + String(sourceMAC,16) + "(hex)");
-          transmitLoRa(&sourceMAC, &ACK, 1);  // Send ACK back to source
-          ackOkLoRaMsg++;
-        }
-        else {
-          SystemPacket NAK = { .cmd = cmd_ack, .param = CRC_BAD };
-          // Send NAK packet to sensor
-          DBG("CRC Mismatch! Packet CRC is 0x" + String(packetCRC,16) + ", Calculated CRC is 0x" + String(calcCRC,16) + " Sending NAK packet to sensor 0x" + String(sourceMAC,16) + "(hex)");
-          transmitLoRa(&sourceMAC, &NAK, 1); // CRC did not match so send NAK to source
-          newData = event_clear;  // do not process data as data may be corrupt
-          return;  // Exit function and do not update newData to send invalid data further on
-        }
+      else {
+        SystemPacket NAK = { .cmd = cmd_ack, .param = CRC_BAD };
+        // Send NAK packet to sensor
+        DBG("CRC Mismatch! Packet CRC is 0x" + String(packetCRC,16) + ", Calculated CRC is 0x" + String(calcCRC,16) + " Sending NAK packet to sensor 0x" + String(sourceMAC,16) + "(hex)");
+        transmitLoRa(&sourceMAC, &NAK, 1); // CRC did not match so send NAK to source
+        newData = event_clear;  // do not process data as data may be corrupt
+        return;  // Exit function and do not update newData to send invalid data further on
       }
+    
       if (memcmp(&sourceMAC, &LoRa1, 2) == 0) {      //Check if it is from a registered sender
         newData = event_lora1;
         return;
@@ -563,7 +562,7 @@ void getLoRa() {
   }
   else {
     if(packetSize != 0) {
-      DBG("Incoming LoRa packet of " + String(packetSize) + " not processed.");
+      DBG("Incoming LoRa packet of " + String(packetSize) + "bytes not processed.");
     }
   }
 #endif

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -262,13 +262,12 @@ void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
   pkt[2] = (LoRaAddress >> 8);
   pkt[3] = (LoRaAddress & 0x00FF);
   memcpy(&pkt[4], packet, len * sizeof(DataReading));
-#ifdef LORA_ACK
   for(int i = 0; i < (sizeof(pkt) - 2); i++) {  // Last 2 bytes are CRC so do not include them in the calculation itself
     //printf("CRC: %02X : %d\n",calcCRC, i);
     calcCRC = crc16_update(calcCRC, pkt[i]);
   }
-#else
-  calcCRC = LORA_NOACK_CRC;
+#ifndef LORA_ACK
+  calcCRC = crc16_update(calcCRC, 0xA1); // Recalculate CRC for No ACK
 #endif    // LORA_ACK
   pkt[len * sizeof(DataReading) + 4] = (calcCRC >> 8);
   pkt[len * sizeof(DataReading) + 5] = (calcCRC & 0x00FF);

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -43,7 +43,7 @@
 #endif //USE_LORA
 
 #ifdef FDRS_DEBUG
-#define DBG(a) (Serial.println(a))
+#define DBG(a) (Serial.println(millis()) + ": " + a))
 #else
 #define DBG(a)
 #endif

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -57,10 +57,27 @@ typedef struct __attribute__((packed)) DataReading {
 
 } DataReading;
 
+
+enum crcResult{
+  CRC_NULL,
+  CRC_OK,
+  CRC_BAD,
+} returnCRC;
+
+enum {
+  cmd_clear,
+  cmd_ping,
+  cmd_add,
+  cmd_ack,
+};
+
 const uint16_t espnow_size = 250 / sizeof(DataReading);
 uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
-uint8_t gtwyAddress[] = {gatewayAddress[3], gatewayAddress[4], GTWY_MAC};
-uint8_t LoRaAddress[] = {0x42, 0x00};
+uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
+uint16_t LoRaAddress = 0x4200;
+unsigned long transmitLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size
+unsigned long msgOkLoRa = 0;     // Number of total LoRa packets with valid CRC
+
 
 uint32_t wait_time = 0;
 DataReading fdrsData[espnow_size];
@@ -159,16 +176,143 @@ void beginFDRS() {
 #endif // USE_LORA
 }
 
-void transmitLoRa(uint8_t* mac, DataReading * packet, uint8_t len) {
+//  USED to get ACKs from LoRa gateway at this point.  May be used in the future to get other data
+// Return type is crcResult struct - CRC_OK, CRC_BAD, CRC_NULL.  CRC_NULL used for non-ack data
+crcResult getLoRa() {
 #ifdef USE_LORA
-  uint8_t pkt[5 + (len * sizeof(DataReading))];
-  memcpy(&pkt, mac, 3);  //
-  memcpy(&pkt[3], &LoRaAddress, 2);
-  memcpy(&pkt[5], packet, len * sizeof(DataReading));
+  int packetSize = LoRa.parsePacket();
+  if ((packetSize - 6) % sizeof(SystemPacket) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of SystemPacket
+    uint8_t packet[packetSize];
+    uint16_t sourceMAC = 0x0000;
+    uint16_t destMAC = 0x0000;
+    uint16_t packetCRC = 0x0000; // CRC Extracted from received LoRa packet
+    uint16_t calcCRC = 0x0000; // CRC calculated from received LoRa packet
+    uint ln = (packetSize - 6) / sizeof(SystemPacket);
+    SystemPacket receiveData[ln];
+  
+    LoRa.readBytes((uint8_t *)&packet, packetSize);
+    
+    destMAC = (packet[0] << 8) | packet[1];
+    sourceMAC = (packet[2] << 8) | packet[3];
+    packetCRC = ((packet[packetSize - 2] << 8) | packet[packetSize - 1]);
+    DBG("Incoming LoRa. Size: " + String(packetSize) + " Bytes, RSSI: " + String(LoRa.packetRssi()) + "dBi, SNR: " + String(LoRa.packetSnr()) + "dB, PacketCRC: 0x" + String(packetCRC,16));
+    if (destMAC == LoRaAddress) {
+      //printLoraPacket(packet,sizeof(packet));
+      memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+      if(ln == 1 && receiveData[0].cmd == cmd_ack) { // We have received an ACK packet
+        if(packetCRC == 0xFFFF) {
+          DBG("ACK Received - address 0x" + String(sourceMAC,16) + "(hex) does not want ACKs");
+          return CRC_OK;
+        }
+        else {
+          for(int i = 0; i < (packetSize - 2); i++) { // Last 2 bytes of packet are the CRC so do not include them in calculation
+            //printf("CRC: %02X : %d\n",calcCRC, i);
+            calcCRC = crc16_update(calcCRC, packet[i]);
+          }
+          if(calcCRC == packetCRC) {
+            DBG("ACK Received - CRC Match");
+            return CRC_OK;
+          }
+          else {
+            DBG("ACK Received CRC Mismatch! Packet CRC is 0x" + String(packetCRC,16) + ", Calculated CRC is 0x" + String(calcCRC,16));
+            return CRC_BAD;
+          }
+        }
+      }
+      else{ // data we have received is not of type ACK_T.  How we handle is future enhancement.
+        DBG("Received some LoRa SystemPacket data that is not of type ACK.  To be handled in future enhancement.");
+        DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+        return CRC_NULL;
+      }
+    }
+    else if((packetSize - 6) % sizeof(DataReading) == 0) {  // packet size should be 6 bytes plus multiple of size of DataReading)
+      DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received, with DataReading data to be processed.");
+      return CRC_NULL;
+    }
+    else {
+      DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received, not destined to our address.");
+      return CRC_NULL;
+    }
+  }
+  else { 
+    if(packetSize != 0) {
+      DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received");
+    }
+  }
+return CRC_NULL;
+#endif
+}
+
+void printLoraPacket(uint8_t* p,int size) {
+  printf("Printing packet of size %d.",size);
+  for(int i = 0; i < size; i++ ) {
+    if(i % 2 == 0) printf("\n%02d: ", i);
+    printf("%02X ", p[i]);
+  }
+  printf("\n");
+}
+
+void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
+#ifdef USE_LORA
+  uint8_t pkt[6 + (len * sizeof(DataReading))];
+  uint16_t calcCRC = 0x0000;
+
+  pkt[0] = (*destMAC >> 8);
+  pkt[1] = (*destMAC & 0x00FF);
+  pkt[2] = (LoRaAddress >> 8);
+  pkt[3] = (LoRaAddress & 0x00FF);
+  memcpy(&pkt[4], packet, len * sizeof(DataReading));
+#ifdef LORA_ACK
+  for(int i = 0; i < (sizeof(pkt) - 2); i++) {  // Last 2 bytes are CRC so do not include them in the calculation itself
+    //printf("CRC: %02X : %d\n",calcCRC, i);
+    calcCRC = crc16_update(calcCRC, pkt[i]);
+  }
+#else
+  calcCRC = LORA_NOACK_CRC;
+#endif    // LORA_ACK
+  pkt[len * sizeof(DataReading) + 4] = (calcCRC >> 8);
+  pkt[len * sizeof(DataReading) + 5] = (calcCRC & 0x00FF);
+#ifdef LORA_ACK  // Wait for ACK
+  int retries = LORA_RETRIES + 1;
+  while(retries != 0) {
+    if(transmitLoRaMsg != 0)
+      DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC,16) + " to gateway 0x" + String(*destMAC,16) + ". Retries remaining: " + String(retries - 1) + ", CRC OK " + String((float)msgOkLoRa/transmitLoRaMsg*100) + "%");
+    else 
+      DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC,16) + " to gateway 0x" + String(*destMAC,16) + ". Retries remaining: " + String(retries - 1));
+    //printLoraPacket(pkt,sizeof(pkt));
+    LoRa.beginPacket();
+    LoRa.write((uint8_t*)&pkt, sizeof(pkt));
+    LoRa.endPacket();
+    transmitLoRaMsg++;
+    unsigned long loraAckTimeout = millis() + LORA_ACK_TIMEOUT; 
+    retries--;
+    delay(10);
+    while(returnCRC == CRC_NULL && (millis() < loraAckTimeout)) {
+      returnCRC = getLoRa();
+    }
+    if(returnCRC == CRC_OK) {
+      //DBG("LoRa ACK Received! CRC OK");
+      msgOkLoRa++;
+      return;  // we're done
+    }
+    else if(returnCRC == CRC_BAD) {
+      //DBG("LoRa ACK Received! CRC BAD");
+      // Resend original packet again if retries are available
+    }
+    else {
+      DBG("LoRa Timeout waiting for ACK!");
+      // resend original packet again if retries are available
+    }
+  }
+#else   // Send and do not wait for ACK reply
+  DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC,16) + " to gateway 0x" + String(*destMAC,16));
+  //printLoraPacket(pkt,sizeof(pkt));
   LoRa.beginPacket();
   LoRa.write((uint8_t*)&pkt, sizeof(pkt));
   LoRa.endPacket();
-#endif
+  transmitLoRaMsg++;
+#endif    // LORA_ACK
+#endif    // USE_LORA
 }
 
 void sendFDRS() {
@@ -183,6 +327,7 @@ void sendFDRS() {
   DBG(" LoRa sent.");
 #endif
   data_count = 0;
+  returnCRC = CRC_NULL;
 }
 
 void loadFDRS(float d, uint8_t t) {
@@ -210,4 +355,33 @@ void sleepFDRS(int sleep_time) {
 #endif
   DBG(" Delaying.");
   delay(sleep_time * 1000);
+}
+
+
+// CRC16 from https://github.com/4-20ma/ModbusMaster/blob/3a05ff87677a9bdd8e027d6906dc05ca15ca8ade/src/util/crc16.h#L71
+
+/** @ingroup util_crc16
+    Processor-independent CRC-16 calculation.
+    Polynomial: x^16 + x^15 + x^2 + 1 (0xA001)<br>
+    Initial value: 0xFFFF
+    This CRC is normally used in disk-drive controllers.
+    @param uint16_t crc (0x0000..0xFFFF)
+    @param uint8_t a (0x00..0xFF)
+    @return calculated CRC (0x0000..0xFFFF)
+*/
+
+static uint16_t crc16_update(uint16_t crc, uint8_t a)
+{
+  int i;
+
+  crc ^= a;
+  for (i = 0; i < 8; ++i)
+  {
+    if (crc & 1)
+      crc = (crc >> 1) ^ 0xA001;
+    else
+      crc = (crc >> 1);
+  }
+
+  return crc;
 }


### PR DESCRIPTION
If you want this would add a runtime timestamp in front of the debug messages for additional troubleshooting capability.   You can reject this if you don't want this capability.

example:
```
124433:  Connecting to WiFi...
```