### PR TITLE
Use READING_ID as part of LoRa address. #65

### DIFF
--- a/FDRS_Gateway/fdrs_functions.h
+++ b/FDRS_Gateway/fdrs_functions.h
@@ -178,7 +178,6 @@ uint8_t ESPNOW2[] =       {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 #ifdef USE_LORA
 uint16_t LoRa1 =         ((mac_prefix[4] << 8) | LORA1_PEER);  // Use 2 bytes for LoRa addressing instead of previous 3 bytes
 uint16_t LoRa2 =         ((mac_prefix[4] << 8) | LORA2_PEER);
-//uint16_t LoRaAddress = 0x4200;
 uint16_t loraGwAddress = ((selfAddress[4] << 8) | selfAddress[5]); // last 2 bytes of gateway address
 uint16_t loraBroadcast = 0xFFFF;
 unsigned long receivedLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size

--- a/FDRS_Sensor/README.md
+++ b/FDRS_Sensor/README.md
@@ -14,8 +14,8 @@ If available and enabled, the device enters deep-sleep. If ```#DEEP_SLEEP``` is 
 
 ## Options
 
-### ```#define READING_ID  n```
-The identifier of this individual device. Should be a 16-bit integer (0-65535). 
+### ```#define READING_ID  0xnn```
+The identifier of this individual device. Should be a 8-bit hexidecimal value (0x00 - 0xFF).
 ### ```#define GTWY_MAC  0xnn```
 The UNIT_MAC of the gateway that this device will send its data to.
 ### ```#define FDRS_DEBUG```

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -83,7 +83,8 @@ typedef struct __attribute__((packed)) SystemPacket {
 const uint16_t espnow_size = 250 / sizeof(DataReading);
 uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
 uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
-uint16_t LoRaAddress = 0x4200;
+uint16_t LoRaAddress = ((gatewayAddress[4] << 8) | READING_ID);
+uint16_t sensorAddress = ((gatewayAddress[4] << 8) | READING_ID);
 unsigned long transmitLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size
 unsigned long msgOkLoRa = 0;     // Number of total LoRa packets with valid CRC
 
@@ -121,7 +122,7 @@ void beginFDRS() {
   esp_reset_reason_t resetReason;
   resetReason = esp_reset_reason();
 #endif
-  DBG("FDRS Sensor ID " + String(READING_ID) + " initializing...");
+  DBG("FDRS Sensor ID " + String(READING_ID, HEX) + " initializing...");
   DBG(" Gateway: " + String (GTWY_MAC, HEX));
 #ifdef POWER_CTRL
   DBG("Powering up the sensor array!");
@@ -340,7 +341,7 @@ void sendFDRS() {
 }
 
 void loadFDRS(float d, uint8_t t) {
-  DBG("Id: " + String(READING_ID) + " - Type: " + String(t) + " - Data loaded: " + String(d));
+  DBG("Id: " + String(READING_ID, HEX) + " - Type: " + String(t) + " - Data loaded: " + String(d));
   if (data_count > espnow_size) sendFDRS();
   DataReading dr;
   dr.id = READING_ID;

--- a/FDRS_Sensor/fdrs_sensor_config.h
+++ b/FDRS_Sensor/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/1_LoRa_Sensor/fdrs_sensor_config.h
+++ b/examples/1_LoRa_Sensor/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x04 //Address of the nearest gateway
 
 //#define USE_ESPNOW

--- a/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
+++ b/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    2   //Unique ID for this sensor
+#define READING_ID    0x02   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x03 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Controllers/FastLED/FastLED.ino
+++ b/examples/Controllers/FastLED/FastLED.ino
@@ -17,7 +17,7 @@
 #endif
 
 
-#define READING_ID    118        //Unique ID for controller
+#define READING_ID    0x76   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x00       //Gateway MAC
 
 #define DATA_PIN    4

--- a/examples/ESPNOW_Stress_Test/fdrs_sensor_config.h
+++ b/examples/ESPNOW_Stress_Test/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x04 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
@@ -4,7 +4,7 @@
 
 #include <fdrs_globals.h>
 
-#define READING_ID    1   //Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x01 //Address of the nearest gateway
 
 #define USE_ESPNOW

--- a/examples/Universal_Sensor_beta/fdrs_sensor.cpp
+++ b/examples/Universal_Sensor_beta/fdrs_sensor.cpp
@@ -3,7 +3,7 @@
 
 const uint8_t prefix[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE}; // Should only be changed if implementing multiple FDRS systems.
 
-uint8_t LoRaAddress[] = {0x42, 0x00};
+const uint8_t LoRaAddress[] = {prefix[4], _reading_id};
 
 uint32_t wait_time = 0;
 
@@ -25,7 +25,7 @@ void FDRSBase::begin() {
 #ifdef FDRS_DEBUG
     Serial.begin(115200);
 #endif
-    DBG("FDRS Sensor ID " + String(_reading_id) + " initializing...");
+    DBG("FDRS Sensor ID " + String(_reading_id, HEX) + " initializing...");
     DBG(" Gateway: " + String (_gtwy_mac, HEX));
 #ifdef POWER_CTRL
     DBG("Powering up the sensor array!");

--- a/examples/Universal_Sensor_beta/fdrs_sensor_config.h
+++ b/examples/Universal_Sensor_beta/fdrs_sensor_config.h
@@ -10,7 +10,7 @@
 #define FDRS_DEBUG 			// Comment, if you do not want to see debug messages
 #include <fdrs_globals.h> 	// Comment if you want to set specific values for this sensor here
 
-#define READING_ID    1   	//Unique ID for this sensor
+#define READING_ID    0x01   //Unique ID for this sensor - 8 bits hexidecimal
 #define GTWY_MAC      0x04 	//Address of the nearest gateway
 
 #define DEEP_SLEEP

--- a/fdrs_functions.h
+++ b/fdrs_functions.h
@@ -176,7 +176,6 @@ uint8_t ESPNOW2[] =       {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 #ifdef USE_LORA
 uint16_t LoRa1 =         ((mac_prefix[4] << 8) | LORA1_PEER);  // Use 2 bytes for LoRa addressing instead of previous 3 bytes
 uint16_t LoRa2 =         ((mac_prefix[4] << 8) | LORA2_PEER);
-//uint16_t LoRaAddress = 0x4200;
 uint16_t loraGwAddress = ((selfAddress[4] << 8) | selfAddress[5]); // last 2 bytes of gateway address
 uint16_t loraBroadcast = 0xFFFF;
 unsigned long receivedLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -76,9 +76,10 @@ enum {
 };
 
 const uint16_t espnow_size = 250 / sizeof(DataReading);
-uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
-uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
-uint16_t LoRaAddress = 0x4200;
+const uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
+const uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
+const uint16_t LoRaAddress = ((gatewayAddress[4] << 8) | READING_ID);
+const uint16_t sensorAddress = ((gatewayAddress[4] << 8) | READING_ID);
 unsigned long transmitLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size
 unsigned long msgOkLoRa = 0;     // Number of total LoRa packets with valid CRC
 
@@ -95,7 +96,7 @@ void beginFDRS() {
   esp_reset_reason_t resetReason;
   resetReason = esp_reset_reason();
 #endif
-  DBG("FDRS Sensor ID " + String(READING_ID) + " initializing...");
+  DBG("FDRS Sensor ID " + String(READING_ID,16) + " initializing...");
   DBG(" Gateway: " + String (GTWY_MAC, HEX));
 #ifdef POWER_CTRL
   DBG("Powering up the sensor array!");
@@ -310,7 +311,7 @@ void sendFDRS() {
 }
 
 void loadFDRS(float d, uint8_t t) {
-  DBG("Id: " + String(READING_ID) + " - Type: " + String(t) + " - Data loaded: " + String(d));
+  DBG("Id: " + String(READING_ID,16) + " - Type: " + String(t) + " - Data loaded: " + String(d));
   if (data_count > espnow_size) sendFDRS();
   DataReading dr;
   dr.id = READING_ID;


### PR DESCRIPTION
From Discussion #65 

In FDRS_Sensor the readings have a READING_ID in fdrs_sensor_config.h which is designed to be modified by end user for each sensor. However, there is also a LoRaAddress configured in fdrs_sensor.h which file is not designed to be modified by end user. Therefore each sensor would have the same LoRaAddress which is not desirable. Can we make READING_ID part of LoRaAddress?

This PR makes READING_ID part of LoRaAddress so that user does not have to change fdrs_sensor.h