### PR TITLE
Feature add: LoRa SystemPacket ping reply

### DIFF
--- a/FDRS_Gateway/fdrs_functions.h
+++ b/FDRS_Gateway/fdrs_functions.h
@@ -20,13 +20,11 @@ enum {
   event_lora2
 };
 
-
 enum crcResult{
   CRC_NULL,
   CRC_OK,
   CRC_BAD,
 } returnCRC = CRC_NULL;
-
 
 enum {
   cmd_clear,
@@ -39,13 +37,13 @@ enum {
 #define DBG(a) (Serial.println(a))
 #else
 #define DBG(a)
-#endif // FDRS_DEBUG
+#endif
 
 #if defined (ESP32)
 #define UART_IF Serial1
 #else
 #define UART_IF Serial
-#endif // ESP32
+#endif
 
 // enable to get detailed info from where single configuration macros have been taken
 #define DEBUG_NODE_CONFIG
@@ -204,6 +202,7 @@ DataReading theData[256];
 uint8_t ln;
 uint8_t newData = event_clear;
 uint8_t newCmd = cmd_clear;
+bool is_ping = false;
 
 #ifdef USE_ESPNOW
 DataReading ESPNOW1buffer[256];
@@ -422,19 +421,10 @@ void mqtt_publish(const char* payload) {
 #endif //USE_WIFI
 }
 
-void printLoraPacket(uint8_t* p,int size) {
-  printf("Printing packet of size %d.",size);
-  for(int i = 0; i < size; i++ ) {
-    if(i % 2 == 0) printf("\n%02d: ", i);
-    printf("%02X ", p[i]);
-  }
-  printf("\n");
-}
-
-void getLoRa() {
+crcResult getLoRa() {
 #ifdef USE_LORA
   int packetSize = LoRa.parsePacket();
-  if((packetSize - 6) % sizeof(DataReading) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of DataReading
+  if((((packetSize - 6) % sizeof(DataReading) == 0) || ((packetSize - 6) % sizeof(SystemPacket) == 0)) && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of DataReading
     uint8_t packet[packetSize];
     uint16_t packetCRC = 0x0000; // CRC Extracted from received LoRa packet
     uint16_t calcCRC = 0x0000; // CRC calculated from received LoRa packet
@@ -442,7 +432,6 @@ void getLoRa() {
     uint16_t destMAC = 0x0000;
   
     LoRa.readBytes((uint8_t *)&packet, packetSize);
-    ln = (packetSize - 6) / sizeof(DataReading);
     
     destMAC = (packet[0] << 8) | packet[1];
     sourceMAC = (packet[2] << 8) | packet[3];
@@ -450,7 +439,6 @@ void getLoRa() {
     //DBG("Packet Address: 0x" + String(packet[0], HEX) + String(packet[1], HEX) + " Self Address: 0x" + String(selfAddress[4], HEX) + String(selfAddress[5], HEX));
     if (destMAC == (selfAddress[4] << 8 | selfAddress[5])) {   //Check if addressed to this device (2 bytes, bytes 1 and 2)
       //printLoraPacket(packet,sizeof(packet));
-      memcpy(&theData, &packet[4], packetSize - 6);   //Split off data portion of packet (N - 6 bytes (6 bytes for headers and CRC))
       if(receivedLoRaMsg != 0){  // Avoid divide by 0
         DBG("Incoming LoRa. Size: " + String(packetSize) + " Bytes, RSSI: " + String(LoRa.packetRssi()) + "dBm, SNR: " + String(LoRa.packetSnr()) + "dB, PacketCRC: 0x" + String(packetCRC, HEX) + ", Total LoRa received: " + String(receivedLoRaMsg) + ", CRC Ok Pct " + String((float)ackOkLoRaMsg/receivedLoRaMsg*100) + "%");
       }
@@ -463,34 +451,92 @@ void getLoRa() {
         //printf("CRC: %02X : %d\n",calcCRC, i);
         calcCRC = crc16_update(calcCRC, packet[i]);
       }
-      if(calcCRC == packetCRC) {
-        SystemPacket ACK = { .cmd = cmd_ack, .param = CRC_OK };
-        DBG("CRC Match, sending ACK packet to sensor 0x" + String(sourceMAC, HEX) + "(hex)");
-        transmitLoRa(&sourceMAC, &ACK, 1);  // Send ACK back to source
-        ackOkLoRaMsg++;
+      if((packetSize - 6) % sizeof(DataReading) == 0) { // DataReading type packet
+        if(calcCRC == packetCRC) {
+          SystemPacket ACK = { .cmd = cmd_ack, .param = CRC_OK };
+          DBG("CRC Match, sending ACK packet to sensor 0x" + String(sourceMAC, HEX) + "(hex)");
+          transmitLoRa(&sourceMAC, &ACK, 1);  // Send ACK back to source
+        }
+        else if(packetCRC == crc16_update(calcCRC,0xA1)) { // Sender does not want ACK and CRC is valid
+          DBG("Sensor address 0x" + String(sourceMAC,16) + "(hex) does not want ACK");
+        }
+        else {
+          SystemPacket NAK = { .cmd = cmd_ack, .param = CRC_BAD };
+          // Send NAK packet to sensor
+          DBG("CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX) + " Sending NAK packet to sensor 0x" + String(sourceMAC, HEX) + "(hex)");
+          transmitLoRa(&sourceMAC, &NAK, 1); // CRC did not match so send NAK to source
+          newData = event_clear;  // do not process data as data may be corrupt
+          return CRC_BAD;  // Exit function and do not update newData to send invalid data further on
+        }
+          memcpy(&theData, &packet[4], packetSize - 6);   //Split off data portion of packet (N - 6 bytes (6 bytes for headers and CRC))
+          ln = (packetSize - 6) / sizeof(DataReading);
+          ackOkLoRaMsg++;
+        if (memcmp(&sourceMAC, &LoRa1, 2) == 0) {      //Check if it is from a registered sender
+          newData = event_lora1;
+          return CRC_OK;
+        }
+        if (memcmp(&sourceMAC, &LoRa2, 2) == 0) {
+          newData = event_lora2;
+          return CRC_OK;
+        }
+        newData = event_lorag;
+        return CRC_OK;
       }
-      else if(packetCRC == crc16_update(calcCRC,0xA1)) { // Sender does not want ACK and CRC is valid
-        DBG("Sensor address 0x" + String(sourceMAC, HEX) + "(hex) does not want ACK");
-        ackOkLoRaMsg++;
-      }
-      else {
-        SystemPacket NAK = { .cmd = cmd_ack, .param = CRC_BAD };
-        // Send NAK packet to sensor
-        DBG("CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX) + " Sending NAK packet to sensor 0x" + String(sourceMAC, HEX) + "(hex)");
-        transmitLoRa(&sourceMAC, &NAK, 1); // CRC did not match so send NAK to source
-        newData = event_clear;  // do not process data as data may be corrupt
-        return;  // Exit function and do not update newData to send invalid data further on
-      }
+      else if((packetSize - 6) % sizeof(SystemPacket) == 0) {
+        uint ln = (packetSize - 6) / sizeof(SystemPacket);
+        SystemPacket receiveData[ln];
     
-      if (memcmp(&sourceMAC, &LoRa1, 2) == 0) {      //Check if it is from a registered sender
-        newData = event_lora1;
-        return;
+        if(calcCRC == packetCRC) {
+          memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+          if(ln == 1 && receiveData[0].cmd == cmd_ack) {
+            DBG("ACK Received - CRC Match");
+          }
+          else if(ln == 1 && receiveData[0].cmd == cmd_ping) { // We have received a ping request or reply??
+            if(receiveData[0].param == 1) {  // This is a reply to our ping request
+              is_ping = true;
+              DBG("We have received a ping reply via LoRa from address " + String(sourceMAC, HEX));
+            }
+            else if(receiveData[0].param == 0) {
+              DBG("We have received a ping request from 0x" + String(sourceMAC, HEX) + ", Replying.");
+              SystemPacket pingReply = { .cmd = cmd_ping, .param = 1 };
+              transmitLoRa(&sourceMAC, &pingReply, 1);
+            }
+          }
+          else { // data we have received is not yet programmed.  How we handle is future enhancement.
+            DBG("Received some LoRa SystemPacket data that is not yet handled.  To be handled in future enhancement.");
+            DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+          }
+          ackOkLoRaMsg++;
+          return CRC_OK;
+        }
+        else if(packetCRC == crc16_update(calcCRC,0xA1)) { // Sender does not want ACK and CRC is valid
+          memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+          if(ln == 1 && receiveData[0].cmd == cmd_ack) {
+            DBG("ACK Received - CRC Match");
+          }
+          else if(ln == 1 && receiveData[0].cmd == cmd_ping) { // We have received a ping request or reply??
+            if(receiveData[0].param == 1) {  // This is a reply to our ping request
+              is_ping = true;
+              DBG("We have received a ping reply via LoRa from address " + String(sourceMAC, HEX));
+            }
+            else if(receiveData[0].param == 0) {
+              DBG("We have received a ping request from 0x" + String(sourceMAC, HEX) + ", Replying.");
+              SystemPacket pingReply = { .cmd = cmd_ping, .param = 1 };
+              transmitLoRa(&sourceMAC, &pingReply, 1);
+            }
+          }
+          else { // data we have received is not yet programmed.  How we handle is future enhancement.
+            DBG("Received some LoRa SystemPacket data that is not yet handled.  To be handled in future enhancement.");
+            DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+          }
+          ackOkLoRaMsg++;
+          return CRC_OK;
+        }
+        else {
+          DBG("ACK Received CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX));
+          return CRC_BAD;
+        }
       }
-      if (memcmp(&sourceMAC, &LoRa2, 2) == 0) {
-        newData = event_lora2;
-        return;
-      }
-      newData = event_lorag;
     }
     else {
       DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received from address 0x" + String(sourceMAC, HEX) + " destined for node address 0x" + String(destMAC, HEX));
@@ -501,6 +547,7 @@ void getLoRa() {
       DBG("Incoming LoRa packet of " + String(packetSize) + "bytes not processed.");
     }
   }
+  return CRC_NULL;
 #endif //USE_LORA
 }
 
@@ -527,8 +574,33 @@ void transmitLoRa(uint16_t* destMac, DataReading * packet, uint8_t len) {
   LoRa.write((uint8_t*)&pkt, sizeof(pkt));
   LoRa.endPacket();
   }
+#endif
+
+#ifdef USE_LORA
+void transmitLoRa(uint16_t* destMac, SystemPacket * packet, uint8_t len) {
+  uint16_t calcCRC = 0x0000;
+
+  uint8_t pkt[6 + (len * sizeof(SystemPacket))];
+  
+  pkt[0] = (*destMac >> 8);       // high byte of destination MAC
+  pkt[1] = (*destMac & 0x00FF);   // low byte of destination MAC
+  pkt[2] = selfAddress[4];    // high byte of source MAC (ourselves)
+  pkt[3] = selfAddress[5];    // low byte of source MAC
+  memcpy(&pkt[4], packet, len * sizeof(SystemPacket));   // copy data portion of packet
+  for(int i = 0; i < (sizeof(pkt) - 2); i++) {  // Last 2 bytes are CRC so do not include them in the calculation itself
+    //printf("CRC: %02X : %d\n",calcCRC, i);
+    calcCRC = crc16_update(calcCRC, pkt[i]);
 }
-#endif  // USE_LORA
+  calcCRC = crc16_update(calcCRC, 0xA1); // No ACK for SystemPacket messages so generate new CRC with 0xA1
+  pkt[(len * sizeof(SystemPacket) + 4)] = (calcCRC >> 8); // Append calculated CRC to the last 2 bytes of the packet
+  pkt[(len * sizeof(SystemPacket) + 5)] = (calcCRC & 0x00FF);
+  DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to LoRa MAC 0x" + String(*destMac, HEX));
+  //printLoraPacket(pkt,sizeof(pkt));
+  LoRa.beginPacket();
+  LoRa.write((uint8_t*)&pkt, sizeof(pkt));
+  LoRa.endPacket();
+}
+#endif
 
 void sendESPNOW(uint8_t address) {
 #ifdef USE_ESPNOW
@@ -947,6 +1019,7 @@ void handleCommands() {
       DBG("Add sender to peer list (not completed)");
       break;
   }
+  is_ping = false;
   theCmd.cmd = cmd_clear;
   theCmd.param = 0;
 }
@@ -964,8 +1037,7 @@ void handleCommands() {
     @return calculated CRC (0x0000..0xFFFF)
 */
 
-static uint16_t crc16_update(uint16_t crc, uint8_t a)
-{
+static uint16_t crc16_update(uint16_t crc, uint8_t a) {
   int i;
 
   crc ^= a;
@@ -978,6 +1050,15 @@ static uint16_t crc16_update(uint16_t crc, uint8_t a)
   }
 
   return crc;
+}
+
+void printLoraPacket(uint8_t* p,int size) {
+  printf("Printing packet of size %d.",size);
+  for(int i = 0; i < size; i++ ) {
+    if(i % 2 == 0) printf("\n%02d: ", i);
+    printf("%02X ", p[i]);
+  }
+  printf("\n");
 }
 
 #endif //__FDRS_FUNCTIONS_H__

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -94,8 +94,8 @@ const uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
 uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
 const uint16_t LoRaAddress = ((gatewayAddress[4] << 8) | READING_ID);
 const uint16_t sensorAddress = ((gatewayAddress[4] << 8) | READING_ID);
-unsigned long transmitLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size
-unsigned long msgOkLoRa = 0;     // Number of total LoRa packets with valid CRC
+unsigned long transmitLoRaMsgwAck = 0;  // Number of total LoRa packets transmitted and we expect ACK in return
+unsigned long msgOkLoRa = 0;     // Number of total LoRa packets ACKed with valid CRC
 
 
 uint32_t wait_time = 0;
@@ -313,15 +313,15 @@ void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
 #ifdef LORA_ACK  // Wait for ACK
   int retries = LORA_RETRIES + 1;
   while(retries != 0) {
-    if(transmitLoRaMsg != 0)
-      DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to gateway 0x" + String(*destMAC, HEX) + ". Retries remaining: " + String(retries - 1) + ", CRC OK " + String((float)msgOkLoRa/transmitLoRaMsg*100) + "%");
+    if(transmitLoRaMsgwAck != 0)
+      DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to gateway 0x" + String(*destMAC, HEX) + ". Retries remaining: " + String(retries - 1) + ", Ack Ok " + String((float)msgOkLoRa/transmitLoRaMsgwAck*100) + "%");
     else 
       DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to gateway 0x" + String(*destMAC, HEX) + ". Retries remaining: " + String(retries - 1));
     //printLoraPacket(pkt,sizeof(pkt));
     LoRa.beginPacket();
     LoRa.write((uint8_t*)&pkt, sizeof(pkt));
     LoRa.endPacket();
-    transmitLoRaMsg++;
+    transmitLoRaMsgwAck++;
     unsigned long loraAckTimeout = millis() + LORA_ACK_TIMEOUT; 
     retries--;
     delay(10);
@@ -348,7 +348,7 @@ void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
   LoRa.beginPacket();
   LoRa.write((uint8_t*)&pkt, sizeof(pkt));
   LoRa.endPacket();
-  transmitLoRaMsg++;
+  transmitLoRaMsgwAck++;
 #endif    // LORA_ACK
 #endif    // USE_LORA
 }
@@ -376,7 +376,6 @@ void transmitLoRa(uint16_t* destMAC, SystemPacket* packet, uint8_t len) {
   LoRa.beginPacket();
   LoRa.write((uint8_t*)&pkt, sizeof(pkt));
   LoRa.endPacket();
-  transmitLoRaMsg++;
 #endif    // USE_LORA
 }
 

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -75,7 +75,7 @@ enum crcResult{
   CRC_NULL,
   CRC_OK,
   CRC_BAD,
-} returnCRC;
+} returnCRC = CRC_NULL;
 
 enum {
   cmd_clear,
@@ -90,10 +90,10 @@ typedef struct __attribute__((packed)) SystemPacket {
 } SystemPacket;
 
 const uint16_t espnow_size = 250 / sizeof(DataReading);
-uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
+const uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
 uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
-uint16_t LoRaAddress = ((gatewayAddress[4] << 8) | READING_ID);
-uint16_t sensorAddress = ((gatewayAddress[4] << 8) | READING_ID);
+const uint16_t LoRaAddress = ((gatewayAddress[4] << 8) | READING_ID);
+const uint16_t sensorAddress = ((gatewayAddress[4] << 8) | READING_ID);
 unsigned long transmitLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size
 unsigned long msgOkLoRa = 0;     // Number of total LoRa packets with valid CRC
 
@@ -195,17 +195,19 @@ void beginFDRS() {
 
 }
 
-//  USED to get ACKs from LoRa gateway at this point.  May be used in the future to get other data
+// getLoRa for Sensors
+//  USED to get ACKs (SystemPacket type) from LoRa gateway at this point.  May be used in the future to get other data
 // Return type is crcResult struct - CRC_OK, CRC_BAD, CRC_NULL.  CRC_NULL used for non-ack data
 crcResult getLoRa() {
 #ifdef USE_LORA
   int packetSize = LoRa.parsePacket();
-  if ((packetSize - 6) % sizeof(SystemPacket) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of SystemPacket
+  if((packetSize - 6) % sizeof(SystemPacket) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of SystemPacket
     uint8_t packet[packetSize];
-    uint16_t sourceMAC = 0x0000;
-    uint16_t destMAC = 0x0000;
     uint16_t packetCRC = 0x0000; // CRC Extracted from received LoRa packet
     uint16_t calcCRC = 0x0000; // CRC calculated from received LoRa packet
+    uint16_t sourceMAC = 0x0000;
+    uint16_t destMAC = 0x0000;
+    
     uint ln = (packetSize - 6) / sizeof(SystemPacket);
     SystemPacket receiveData[ln];
   
@@ -215,36 +217,62 @@ crcResult getLoRa() {
     sourceMAC = (packet[2] << 8) | packet[3];
     packetCRC = ((packet[packetSize - 2] << 8) | packet[packetSize - 1]);
     DBG("Incoming LoRa. Size: " + String(packetSize) + " Bytes, RSSI: " + String(LoRa.packetRssi()) + "dBm, SNR: " + String(LoRa.packetSnr()) + "dB, PacketCRC: 0x" + String(packetCRC, HEX));
-    if (destMAC == LoRaAddress) {
+    if (destMAC == LoRaAddress) {  // The packet is for us so let's process it
       //printLoraPacket(packet,sizeof(packet));
-      memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
-      if(ln == 1 && receiveData[0].cmd == cmd_ack) { // We have received an ACK packet
-        if(packetCRC == 0xFFFF) {
-          DBG("ACK Received - address 0x" + String(sourceMAC, HEX) + "(hex) does not want ACKs");
-          return CRC_OK;
-        }
-        else {
-          for(int i = 0; i < (packetSize - 2); i++) { // Last 2 bytes of packet are the CRC so do not include them in calculation
-            //printf("CRC: %02X : %d\n",calcCRC, i);
-            calcCRC = crc16_update(calcCRC, packet[i]);
-          }
-          if(calcCRC == packetCRC) {
-            DBG("ACK Received - CRC Match");
-            return CRC_OK;
-          }
-          else {
-            DBG("ACK Received CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX));
-            return CRC_BAD;
-          }
-        }
+      for(int i = 0; i < (packetSize - 2); i++) { // Last 2 bytes of packet are the CRC so do not include them in calculation
+        //printf("CRC: %02X : %d\n",calcCRC, i);
+        calcCRC = crc16_update(calcCRC, packet[i]);
       }
-      else{ // data we have received is not of type ACK_T.  How we handle is future enhancement.
-        DBG("Received some LoRa SystemPacket data that is not of type ACK.  To be handled in future enhancement.");
-        DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
-        return CRC_NULL;
+      if(calcCRC == packetCRC) {
+        memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+        if(ln == 1 && receiveData[0].cmd == cmd_ack) {
+          DBG("ACK Received - CRC Match");
+        }
+        else if(ln == 1 && receiveData[0].cmd == cmd_ping) { // We have received a ping request or reply??
+          if(receiveData[0].param == 1) {  // This is a reply to our ping request
+            is_ping = true;
+            DBG("We have received a ping reply via LoRa from address 0x" + String(sourceMAC, HEX));
+          }
+          else if(receiveData[0].param == 0) {
+            DBG("We have received a ping request from 0x" + String(sourceMAC, HEX) + ", Replying.");
+            SystemPacket pingReply = { .cmd = cmd_ping, .param = 1 };
+            transmitLoRa(&sourceMAC, &pingReply, 1);
+          }
+        }
+        else { // data we have received is not yet programmed.  How we handle is future enhancement.
+          DBG("Received some LoRa SystemPacket data that is not yet handled.  To be handled in future enhancement.");
+          DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+        }
+        return CRC_OK;
+      }
+      else if(packetCRC == crc16_update(calcCRC,0xA1)) { // Sender does not want ACK and CRC is valid
+        memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+        if(ln == 1 && receiveData[0].cmd == cmd_ack) {
+          DBG("ACK Received - CRC Match");
+        }
+        else if(ln == 1 && receiveData[0].cmd == cmd_ping) { // We have received a ping request or reply??
+          if(receiveData[0].param == 1) {  // This is a reply to our ping request
+            is_ping = true;
+            DBG("We have received a ping reply via LoRa from address 0x" + String(sourceMAC, HEX));
+          }
+          else if(receiveData[0].param == 0) {
+            DBG("We have received a ping request from 0x" + String(sourceMAC, HEX) + ", Replying.");
+            SystemPacket pingReply = { .cmd = cmd_ping, .param = 1 };
+            transmitLoRa(&sourceMAC, &pingReply, 1);
+          }
+        }
+        else { // data we have received is not yet programmed.  How we handle is future enhancement.
+          DBG("Received some LoRa SystemPacket data that is not yet handled.  To be handled in future enhancement.");
+          DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+        }
+        return CRC_OK;
+      }
+      else {
+        DBG("ACK Received CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX));
+        return CRC_BAD;
       }
     }
-    else if((packetSize - 6) % sizeof(DataReading) == 0) {  // packet size should be 6 bytes plus multiple of size of DataReading)
+    else if((packetSize - 6) % sizeof(DataReading) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of DataReading)
       DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received, with DataReading data to be processed.");
       return CRC_NULL;
     }
@@ -256,19 +284,11 @@ crcResult getLoRa() {
   else { 
     if(packetSize != 0) {
       DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received");
+      return CRC_NULL;
     }
   }
 return CRC_NULL;
 #endif
-}
-
-void printLoraPacket(uint8_t* p,int size) {
-  printf("Printing packet of size %d.",size);
-  for(int i = 0; i < size; i++ ) {
-    if(i % 2 == 0) printf("\n%02d: ", i);
-    printf("%02X ", p[i]);
-  }
-  printf("\n");
 }
 
 void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
@@ -333,6 +353,33 @@ void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
 #endif    // USE_LORA
 }
 
+// For now SystemPackets will not use ACK but will calculate CRC
+void transmitLoRa(uint16_t* destMAC, SystemPacket* packet, uint8_t len) {
+#ifdef USE_LORA
+  uint8_t pkt[6 + (len * sizeof(SystemPacket))];
+  uint16_t calcCRC = 0x0000;
+
+  pkt[0] = (*destMAC >> 8);
+  pkt[1] = (*destMAC & 0x00FF);
+  pkt[2] = (LoRaAddress >> 8);
+  pkt[3] = (LoRaAddress & 0x00FF);
+  memcpy(&pkt[4], packet, len * sizeof(SystemPacket));
+  for(int i = 0; i < (sizeof(pkt) - 2); i++) {  // Last 2 bytes are CRC so do not include them in the calculation itself
+    //printf("CRC: %02X : %d\n",calcCRC, i);
+    calcCRC = crc16_update(calcCRC, pkt[i]);
+  }
+  calcCRC = crc16_update(calcCRC, 0xA1); // Recalculate CRC for No ACK
+  pkt[len * sizeof(SystemPacket) + 4] = (calcCRC >> 8);
+  pkt[len * sizeof(SystemPacket) + 5] = (calcCRC & 0x00FF);
+  DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to destination 0x" + String(*destMAC, HEX));
+  //printLoraPacket(pkt,sizeof(pkt));
+  LoRa.beginPacket();
+  LoRa.write((uint8_t*)&pkt, sizeof(pkt));
+  LoRa.endPacket();
+  transmitLoRaMsg++;
+#endif    // USE_LORA
+}
+
 void sendFDRS() {
   DBG("Sending FDRS Packet!");
 #ifdef USE_ESPNOW
@@ -342,6 +389,7 @@ void sendFDRS() {
 #endif
 #ifdef USE_LORA
   transmitLoRa(&gtwyAddress, fdrsData, data_count);
+  DBG(" LoRa sent.");
 #endif
   data_count = 0;
   returnCRC = CRC_NULL;
@@ -377,6 +425,7 @@ void sleepFDRS(int sleep_time) {
 void pingFDRS(int timeout) {
   SystemPacket sys_packet;
   sys_packet.cmd = cmd_ping;
+  sys_packet.param = 0; // 0 for Ping Request and 1 for Ping Reply???
 #ifdef USE_ESPNOW
   esp_now_send(gatewayAddress, (uint8_t *) &sys_packet, sizeof(SystemPacket));
   DBG(" ESP-NOW ping sent.");
@@ -386,15 +435,29 @@ void pingFDRS(int timeout) {
     yield(); //do I need to yield or does it automatically?
     if (is_ping) {
       DBG("Ping Returned:" + String(millis() - ping_start));
+      is_ping = false;
       break;
     }
   }
-
-#endif
+#endif // USE_ESPNOW
 #ifdef USE_LORA
-  //transmitLoRa(gtwyAddress, sys_packet, data_count); // TODO: Make this congruent to esp_now_send()
-  DBG(" LoRa ping not sent because it isn't implemented.");
-#endif
+  transmitLoRa(&gtwyAddress, &sys_packet, 1); // TODO: Make this congruent to esp_now_send()
+  DBG("LoRa ping sent to gateway address: 0x" + String(gtwyAddress, HEX));
+  uint32_t ping_start = millis();
+  is_ping = false;
+  while ((millis() - ping_start) <= timeout) {
+    getLoRa();
+    yield(); //do I need to yield or does it automatically?
+    if(is_ping) {
+      DBG("LoRa Ping Returned: " + String(millis() - ping_start) + "ms.");
+      break;
+    }
+  }
+  if(!is_ping) {
+    DBG("No LoRa ping returned within " + String(timeout) + "ms.");
+  }
+  is_ping = false;
+#endif // USE_LORA
 }
 
 // CRC16 from https://github.com/4-20ma/ModbusMaster/blob/3a05ff87677a9bdd8e027d6906dc05ca15ca8ade/src/util/crc16.h#L71
@@ -424,3 +487,14 @@ static uint16_t crc16_update(uint16_t crc, uint8_t a)
 
   return crc;
 }
+
+#ifdef USE_LORA
+void printLoraPacket(uint8_t* p,int size) {
+  printf("Printing packet of size %d.",size);
+  for(int i = 0; i < size; i++ ) {
+    if(i % 2 == 0) printf("\n%02d: ", i);
+    printf("%02X ", p[i]);
+  }
+  printf("\n");
+}
+#endif // USE_LORA

--- a/fdrs_functions.h
+++ b/fdrs_functions.h
@@ -202,6 +202,7 @@ uint32_t timeLOGBUF = 0;
 DataReading theData[256];
 uint8_t ln;
 uint8_t newData = event_clear;
+bool is_ping = false;
 
 #ifdef USE_ESPNOW
 DataReading ESPNOW1buffer[256];
@@ -413,19 +414,10 @@ void mqtt_publish(const char* payload) {
 #endif //USE_WIFI
 }
 
-void printLoraPacket(uint8_t* p,int size) {
-  printf("Printing packet of size %d.",size);
-  for(int i = 0; i < size; i++ ) {
-    if(i % 2 == 0) printf("\n%02d: ", i);
-    printf("%02X ", p[i]);
-  }
-  printf("\n");
-}
-
-void getLoRa() {
+crcResult getLoRa() {
 #ifdef USE_LORA
   int packetSize = LoRa.parsePacket();
-  if((packetSize - 6) % sizeof(DataReading) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of DataReading
+  if((((packetSize - 6) % sizeof(DataReading) == 0) || ((packetSize - 6) % sizeof(SystemPacket) == 0)) && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of DataReading
     uint8_t packet[packetSize];
     uint16_t packetCRC = 0x0000; // CRC Extracted from received LoRa packet
     uint16_t calcCRC = 0x0000; // CRC calculated from received LoRa packet
@@ -433,7 +425,6 @@ void getLoRa() {
     uint16_t destMAC = 0x0000;
   
     LoRa.readBytes((uint8_t *)&packet, packetSize);
-    ln = (packetSize - 6) / sizeof(DataReading);
     
     destMAC = (packet[0] << 8) | packet[1];
     sourceMAC = (packet[2] << 8) | packet[3];
@@ -441,7 +432,6 @@ void getLoRa() {
     //DBG("Packet Address: 0x" + String(packet[0], HEX) + String(packet[1], HEX) + " Self Address: 0x" + String(selfAddress[4], HEX) + String(selfAddress[5], HEX));
     if (destMAC == (selfAddress[4] << 8 | selfAddress[5])) {   //Check if addressed to this device (2 bytes, bytes 1 and 2)
       //printLoraPacket(packet,sizeof(packet));
-      memcpy(&theData, &packet[4], packetSize - 6);   //Split off data portion of packet (N - 6 bytes (6 bytes for headers and CRC))
       if(receivedLoRaMsg != 0){  // Avoid divide by 0
         DBG("Incoming LoRa. Size: " + String(packetSize) + " Bytes, RSSI: " + String(LoRa.packetRssi()) + "dBm, SNR: " + String(LoRa.packetSnr()) + "dB, PacketCRC: 0x" + String(packetCRC, HEX) + ", Total LoRa received: " + String(receivedLoRaMsg) + ", CRC Ok Pct " + String((float)ackOkLoRaMsg/receivedLoRaMsg*100) + "%");
       }
@@ -454,34 +444,92 @@ void getLoRa() {
         //printf("CRC: %02X : %d\n",calcCRC, i);
         calcCRC = crc16_update(calcCRC, packet[i]);
       }
-      if(calcCRC == packetCRC) {
-        SystemPacket ACK = { .cmd = cmd_ack, .param = CRC_OK };
-        DBG("CRC Match, sending ACK packet to sensor 0x" + String(sourceMAC, HEX) + "(hex)");
-        transmitLoRa(&sourceMAC, &ACK, 1);  // Send ACK back to source
+      if((packetSize - 6) % sizeof(DataReading) == 0) { // DataReading type packet
+        if(calcCRC == packetCRC) {
+          SystemPacket ACK = { .cmd = cmd_ack, .param = CRC_OK };
+          DBG("CRC Match, sending ACK packet to sensor 0x" + String(sourceMAC, HEX) + "(hex)");
+          transmitLoRa(&sourceMAC, &ACK, 1);  // Send ACK back to source
+        }
+        else if(packetCRC == crc16_update(calcCRC,0xA1)) { // Sender does not want ACK and CRC is valid
+          DBG("Sensor address 0x" + String(sourceMAC,16) + "(hex) does not want ACK");
+        }
+        else {
+          SystemPacket NAK = { .cmd = cmd_ack, .param = CRC_BAD };
+          // Send NAK packet to sensor
+          DBG("CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX) + " Sending NAK packet to sensor 0x" + String(sourceMAC, HEX) + "(hex)");
+          transmitLoRa(&sourceMAC, &NAK, 1); // CRC did not match so send NAK to source
+          newData = event_clear;  // do not process data as data may be corrupt
+          return CRC_BAD;  // Exit function and do not update newData to send invalid data further on
+        }
+        memcpy(&theData, &packet[4], packetSize - 6);   //Split off data portion of packet (N - 6 bytes (6 bytes for headers and CRC))
+        ln = (packetSize - 6) / sizeof(DataReading);
         ackOkLoRaMsg++;
+        if (memcmp(&sourceMAC, &LoRa1, 2) == 0) {      //Check if it is from a registered sender
+          newData = event_lora1;
+          return CRC_OK;
+        }
+        if (memcmp(&sourceMAC, &LoRa2, 2) == 0) {
+          newData = event_lora2;
+          return CRC_OK;
+        }
+        newData = event_lorag;
+        return CRC_OK;
       }
-      else if(packetCRC == crc16_update(calcCRC,0xA1)) { // Sender does not want ACK and CRC is valid
-        DBG("Sensor address 0x" + String(sourceMAC, HEX) + "(hex) does not want ACK");
-        ackOkLoRaMsg++;
-      }
-      else {
-        SystemPacket NAK = { .cmd = cmd_ack, .param = CRC_BAD };
-        // Send NAK packet to sensor
-        DBG("CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX) + " Sending NAK packet to sensor 0x" + String(sourceMAC, HEX) + "(hex)");
-        transmitLoRa(&sourceMAC, &NAK, 1); // CRC did not match so send NAK to source
-        newData = event_clear;  // do not process data as data may be corrupt
-        return;  // Exit function and do not update newData to send invalid data further on
-      }
+      else if((packetSize - 6) % sizeof(SystemPacket) == 0) {
+        uint ln = (packetSize - 6) / sizeof(SystemPacket);
+        SystemPacket receiveData[ln];
     
-      if (memcmp(&sourceMAC, &LoRa1, 2) == 0) {      //Check if it is from a registered sender
-        newData = event_lora1;
-        return;
+        if(calcCRC == packetCRC) {
+          memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+          if(ln == 1 && receiveData[0].cmd == cmd_ack) {
+            DBG("ACK Received - CRC Match");
+          }
+          else if(ln == 1 && receiveData[0].cmd == cmd_ping) { // We have received a ping request or reply??
+            if(receiveData[0].param == 1) {  // This is a reply to our ping request
+              is_ping = true;
+              DBG("We have received a ping reply via LoRa from address " + String(sourceMAC, HEX));
+            }
+            else if(receiveData[0].param == 0) {
+              DBG("We have received a ping request from 0x" + String(sourceMAC, HEX) + ", Replying.");
+              SystemPacket pingReply = { .cmd = cmd_ping, .param = 1 };
+              transmitLoRa(&sourceMAC, &pingReply, 1);
+            }
+          }
+          else { // data we have received is not yet programmed.  How we handle is future enhancement.
+            DBG("Received some LoRa SystemPacket data that is not yet handled.  To be handled in future enhancement.");
+            DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+          }
+          ackOkLoRaMsg++;
+          return CRC_OK;
+        }
+        else if(packetCRC == crc16_update(calcCRC,0xA1)) { // Sender does not want ACK and CRC is valid
+          memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+          if(ln == 1 && receiveData[0].cmd == cmd_ack) {
+            DBG("ACK Received - CRC Match");
+          }
+          else if(ln == 1 && receiveData[0].cmd == cmd_ping) { // We have received a ping request or reply??
+            if(receiveData[0].param == 1) {  // This is a reply to our ping request
+              is_ping = true;
+              DBG("We have received a ping reply via LoRa from address " + String(sourceMAC, HEX));
+            }
+            else if(receiveData[0].param == 0) {
+              DBG("We have received a ping request from 0x" + String(sourceMAC, HEX) + ", Replying.");
+              SystemPacket pingReply = { .cmd = cmd_ping, .param = 1 };
+              transmitLoRa(&sourceMAC, &pingReply, 1);
+            }
+          }
+          else { // data we have received is not yet programmed.  How we handle is future enhancement.
+            DBG("Received some LoRa SystemPacket data that is not yet handled.  To be handled in future enhancement.");
+            DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+          }
+          ackOkLoRaMsg++;
+          return CRC_OK;
+        }
+        else {
+          DBG("ACK Received CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX));
+          return CRC_BAD;
+        }
       }
-      if (memcmp(&sourceMAC, &LoRa2, 2) == 0) {
-        newData = event_lora2;
-        return;
-      }
-      newData = event_lorag;
     }
     else {
       DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received from address 0x" + String(sourceMAC, HEX) + " destined for node address 0x" + String(destMAC, HEX));
@@ -492,6 +540,7 @@ void getLoRa() {
       DBG("Incoming LoRa packet of " + String(packetSize) + "bytes not processed.");
     }
   }
+  return CRC_NULL;
 #endif //USE_LORA
 }
 
@@ -535,6 +584,7 @@ void transmitLoRa(uint16_t* destMac, SystemPacket * packet, uint8_t len) {
     //printf("CRC: %02X : %d\n",calcCRC, i);
     calcCRC = crc16_update(calcCRC, pkt[i]);
   }
+  calcCRC = crc16_update(calcCRC, 0xA1); // No ACK for SystemPacket messages so generate new CRC with 0xA1
   pkt[(len * sizeof(SystemPacket) + 4)] = (calcCRC >> 8); // Append calculated CRC to the last 2 bytes of the packet
   pkt[(len * sizeof(SystemPacket) + 5)] = (calcCRC & 0x00FF);
   DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to LoRa MAC 0x" + String(*destMac, HEX));
@@ -632,7 +682,7 @@ void bufferESPNOW(uint8_t interface) {
       lenESPNOW2 +=  ln;
       break;
   }
-#endif USE_ESPNOW
+#endif // USE_ESPNOW
 }
 
 void bufferSerial() {
@@ -738,8 +788,9 @@ void releaseESPNOW(uint8_t interface) {
         break;
       }
   }
-#endif USE_ESPNOW
+#endif // USE_ESPNOW
 }
+
 
 void releaseLoRa(uint8_t interface) {
 #ifdef USE_LORA
@@ -898,6 +949,7 @@ void begin_lora() {
     DBG(" Initialization failed!");
     while (1);
   }
+  LoRa.setSpreadingFactor(FDRS_SF);
   LoRa.setTxPower(LORA_TXPWR);
   DBG("LoRa Initialized. Band: " + String(FDRS_BAND) + " SF: " + String(FDRS_SF) + " Tx Power: " + String(LORA_TXPWR) + " dBm");
 #endif // USE_LORA
@@ -934,6 +986,36 @@ void begin_FS() {
 #endif // USE_FS_LOG
 }
 
+void handleCommands() {
+  switch (theCmd.cmd) {
+    case cmd_ping:
+      DBG("Ping back to sender");
+      SystemPacket sys_packet;
+      sys_packet.cmd = cmd_ping;
+#if defined(ESP32)
+      esp_now_peer_info_t peerInfo;
+      peerInfo.ifidx = WIFI_IF_STA;
+      peerInfo.channel = 0;
+      peerInfo.encrypt = false;
+      memcpy(peerInfo.peer_addr, incMAC, 6);
+      if (esp_now_add_peer(&peerInfo) != ESP_OK) {
+        DBG("Failed to add peer");
+        return;
+      }
+#endif
+      esp_now_send(incMAC, (uint8_t *) &sys_packet, sizeof(SystemPacket));
+        esp_now_del_peer(incMAC);
+      break;
+    case cmd_add:
+      DBG("Add sender to peer list (not completed)");
+      break;
+  }
+  is_ping = false;
+  theCmd.cmd = cmd_clear;
+  theCmd.param = 0;
+}
+
+
 // CRC16 from https://github.com/4-20ma/ModbusMaster/blob/3a05ff87677a9bdd8e027d6906dc05ca15ca8ade/src/util/crc16.h#L71
 
 /** @ingroup util_crc16
@@ -946,8 +1028,7 @@ void begin_FS() {
     @return calculated CRC (0x0000..0xFFFF)
 */
 
-static uint16_t crc16_update(uint16_t crc, uint8_t a)
-{
+static uint16_t crc16_update(uint16_t crc, uint8_t a) {
   int i;
 
   crc ^= a;
@@ -960,6 +1041,15 @@ static uint16_t crc16_update(uint16_t crc, uint8_t a)
   }
 
   return crc;
+}
+
+void printLoraPacket(uint8_t* p,int size) {
+  printf("Printing packet of size %d.",size);
+  for(int i = 0; i < size; i++ ) {
+    if(i % 2 == 0) printf("\n%02d: ", i);
+    printf("%02X ", p[i]);
+  }
+  printf("\n");
 }
 
 #endif //__FDRS_FUNCTIONS_H__

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -94,8 +94,8 @@ const uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
 uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
 const uint16_t LoRaAddress = ((gatewayAddress[4] << 8) | READING_ID);
 const uint16_t sensorAddress = ((gatewayAddress[4] << 8) | READING_ID);
-unsigned long transmitLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size
-unsigned long msgOkLoRa = 0;     // Number of total LoRa packets with valid CRC
+unsigned long transmitLoRaMsgwAck = 0;  // Number of total LoRa packets transmitted and we expect ACK in return
+unsigned long msgOkLoRa = 0;     // Number of total LoRa packets ACKed with valid CRC
 
 
 uint32_t wait_time = 0;
@@ -308,15 +308,15 @@ void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
 #ifdef LORA_ACK  // Wait for ACK
   int retries = LORA_RETRIES + 1;
   while(retries != 0) {
-    if(transmitLoRaMsg != 0)
-      DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to gateway 0x" + String(*destMAC, HEX) + ". Retries remaining: " + String(retries - 1) + ", CRC OK " + String((float)msgOkLoRa/transmitLoRaMsg*100) + "%");
+    if(transmitLoRaMsgwAck != 0)
+      DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to gateway 0x" + String(*destMAC, HEX) + ". Retries remaining: " + String(retries - 1) + ", Ack Ok " + String((float)msgOkLoRa/transmitLoRaMsgwAck*100) + "%");
     else 
       DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to gateway 0x" + String(*destMAC, HEX) + ". Retries remaining: " + String(retries - 1));
     //printLoraPacket(pkt,sizeof(pkt));
     LoRa.beginPacket();
     LoRa.write((uint8_t*)&pkt, sizeof(pkt));
     LoRa.endPacket();
-    transmitLoRaMsg++;
+    transmitLoRaMsgwAck++;
     unsigned long loraAckTimeout = millis() + LORA_ACK_TIMEOUT; 
     retries--;
     delay(10);
@@ -343,7 +343,7 @@ void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
   LoRa.beginPacket();
   LoRa.write((uint8_t*)&pkt, sizeof(pkt));
   LoRa.endPacket();
-  transmitLoRaMsg++;
+  transmitLoRaMsgwAck++;
 #endif    // LORA_ACK
 #endif    // USE_LORA
 }
@@ -371,7 +371,6 @@ void transmitLoRa(uint16_t* destMAC, SystemPacket* packet, uint8_t len) {
   LoRa.beginPacket();
   LoRa.write((uint8_t*)&pkt, sizeof(pkt));
   LoRa.endPacket();
-  transmitLoRaMsg++;
 #endif    // USE_LORA
 }
 

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -75,7 +75,7 @@ enum crcResult{
   CRC_NULL,
   CRC_OK,
   CRC_BAD,
-} returnCRC;
+} returnCRC = CRC_NULL;
 
 enum {
   cmd_clear,
@@ -84,9 +84,14 @@ enum {
   cmd_ack,
 };
 
+typedef struct __attribute__((packed)) SystemPacket {
+  uint8_t cmd;
+  uint32_t param;
+} SystemPacket;
+
 const uint16_t espnow_size = 250 / sizeof(DataReading);
 const uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
-const uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
+uint16_t gtwyAddress = ((gatewayAddress[4] << 8) | GTWY_MAC);
 const uint16_t LoRaAddress = ((gatewayAddress[4] << 8) | READING_ID);
 const uint16_t sensorAddress = ((gatewayAddress[4] << 8) | READING_ID);
 unsigned long transmitLoRaMsg = 0;  // Number of total LoRa packets destined for us and of valid size
@@ -96,6 +101,27 @@ unsigned long msgOkLoRa = 0;     // Number of total LoRa packets with valid CRC
 uint32_t wait_time = 0;
 DataReading fdrsData[espnow_size];
 uint8_t data_count = 0;
+bool is_ping = false;
+
+// Set ESP-NOW send and receive callbacks for either ESP8266 or ESP32
+#if defined(ESP8266)
+void OnDataSent(uint8_t *mac_addr, uint8_t sendStatus) {
+}
+void OnDataRecv(uint8_t* mac, uint8_t *incomingData, uint8_t len) {
+#elif defined(ESP32)
+void OnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status) {
+}
+void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
+#endif
+  if (len < sizeof(DataReading)) {
+    SystemPacket command;
+    memcpy(&command, incomingData, sizeof(command));
+    if (command.cmd == cmd_ping) {
+      is_ping = true;
+      return;
+    }
+  }
+}
 
 
 void beginFDRS() {
@@ -105,7 +131,7 @@ void beginFDRS() {
   esp_reset_reason_t resetReason;
   resetReason = esp_reset_reason();
 #endif
-  DBG("FDRS Sensor ID " + String(READING_ID,16) + " initializing...");
+  DBG("FDRS Sensor ID " + String(READING_ID, HEX) + " initializing...");
   DBG(" Gateway: " + String (GTWY_MAC, HEX));
 #ifdef POWER_CTRL
   DBG("Powering up the sensor array!");
@@ -164,17 +190,19 @@ void beginFDRS() {
 
 }
 
-//  USED to get ACKs from LoRa gateway at this point.  May be used in the future to get other data
+// getLoRa for Sensors
+//  USED to get ACKs (SystemPacket type) from LoRa gateway at this point.  May be used in the future to get other data
 // Return type is crcResult struct - CRC_OK, CRC_BAD, CRC_NULL.  CRC_NULL used for non-ack data
 crcResult getLoRa() {
 #ifdef USE_LORA
   int packetSize = LoRa.parsePacket();
-  if ((packetSize - 6) % sizeof(SystemPacket) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of SystemPacket
+  if((packetSize - 6) % sizeof(SystemPacket) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of SystemPacket
     uint8_t packet[packetSize];
-    uint16_t sourceMAC = 0x0000;
-    uint16_t destMAC = 0x0000;
     uint16_t packetCRC = 0x0000; // CRC Extracted from received LoRa packet
     uint16_t calcCRC = 0x0000; // CRC calculated from received LoRa packet
+    uint16_t sourceMAC = 0x0000;
+    uint16_t destMAC = 0x0000;
+    
     uint ln = (packetSize - 6) / sizeof(SystemPacket);
     SystemPacket receiveData[ln];
   
@@ -184,36 +212,62 @@ crcResult getLoRa() {
     sourceMAC = (packet[2] << 8) | packet[3];
     packetCRC = ((packet[packetSize - 2] << 8) | packet[packetSize - 1]);
     DBG("Incoming LoRa. Size: " + String(packetSize) + " Bytes, RSSI: " + String(LoRa.packetRssi()) + "dBm, SNR: " + String(LoRa.packetSnr()) + "dB, PacketCRC: 0x" + String(packetCRC, HEX));
-    if (destMAC == LoRaAddress) {
+    if (destMAC == LoRaAddress) {  // The packet is for us so let's process it
       //printLoraPacket(packet,sizeof(packet));
-      memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
-      if(ln == 1 && receiveData[0].cmd == cmd_ack) { // We have received an ACK packet
-        if(packetCRC == 0xFFFF) {
-          DBG("ACK Received - address 0x" + String(sourceMAC, HEX) + "(hex) does not want ACKs");
-          return CRC_OK;
-        }
-        else {
-          for(int i = 0; i < (packetSize - 2); i++) { // Last 2 bytes of packet are the CRC so do not include them in calculation
-            //printf("CRC: %02X : %d\n",calcCRC, i);
-            calcCRC = crc16_update(calcCRC, packet[i]);
-          }
-          if(calcCRC == packetCRC) {
-            DBG("ACK Received - CRC Match");
-            return CRC_OK;
-          }
-          else {
-            DBG("ACK Received CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX));
-            return CRC_BAD;
-          }
-        }
+      for(int i = 0; i < (packetSize - 2); i++) { // Last 2 bytes of packet are the CRC so do not include them in calculation
+          //printf("CRC: %02X : %d\n",calcCRC, i);
+          calcCRC = crc16_update(calcCRC, packet[i]);
       }
-      else{ // data we have received is not of type ACK_T.  How we handle is future enhancement.
-        DBG("Received some LoRa SystemPacket data that is not of type ACK.  To be handled in future enhancement.");
-        DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
-        return CRC_NULL;
+      if(calcCRC == packetCRC) {
+        memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+        if(ln == 1 && receiveData[0].cmd == cmd_ack) {
+          DBG("ACK Received - CRC Match");
+        }
+        else if(ln == 1 && receiveData[0].cmd == cmd_ping) { // We have received a ping request or reply??
+          if(receiveData[0].param == 1) {  // This is a reply to our ping request
+            is_ping = true;
+            DBG("We have received a ping reply via LoRa from address 0x" + String(sourceMAC, HEX));
+          }
+          else if(receiveData[0].param == 0) {
+            DBG("We have received a ping request from 0x" + String(sourceMAC, HEX) + ", Replying.");
+            SystemPacket pingReply = { .cmd = cmd_ping, .param = 1 };
+            transmitLoRa(&sourceMAC, &pingReply, 1);
+          }
+        }
+        else { // data we have received is not yet programmed.  How we handle is future enhancement.
+          DBG("Received some LoRa SystemPacket data that is not yet handled.  To be handled in future enhancement.");
+          DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+        }
+        return CRC_OK;
+      }
+      else if(packetCRC == crc16_update(calcCRC,0xA1)) { // Sender does not want ACK and CRC is valid
+        memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
+        if(ln == 1 && receiveData[0].cmd == cmd_ack) {
+          DBG("ACK Received - CRC Match");
+        }
+        else if(ln == 1 && receiveData[0].cmd == cmd_ping) { // We have received a ping request or reply??
+          if(receiveData[0].param == 1) {  // This is a reply to our ping request
+            is_ping = true;
+            DBG("We have received a ping reply via LoRa from address 0x" + String(sourceMAC, HEX));
+          }
+          else if(receiveData[0].param == 0) {
+            DBG("We have received a ping request from 0x" + String(sourceMAC, HEX) + ", Replying.");
+            SystemPacket pingReply = { .cmd = cmd_ping, .param = 1 };
+            transmitLoRa(&sourceMAC, &pingReply, 1);
+          }
+        }
+        else { // data we have received is not yet programmed.  How we handle is future enhancement.
+          DBG("Received some LoRa SystemPacket data that is not yet handled.  To be handled in future enhancement.");
+          DBG("ln: " + String(ln) + "data type: " + String(receiveData[0].cmd));
+        }
+        return CRC_OK;
+      }
+      else {
+        DBG("ACK Received CRC Mismatch! Packet CRC is 0x" + String(packetCRC, HEX) + ", Calculated CRC is 0x" + String(calcCRC, HEX));
+        return CRC_BAD;
       }
     }
-    else if((packetSize - 6) % sizeof(DataReading) == 0) {  // packet size should be 6 bytes plus multiple of size of DataReading)
+    else if((packetSize - 6) % sizeof(DataReading) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of DataReading)
       DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received, with DataReading data to be processed.");
       return CRC_NULL;
     }
@@ -225,19 +279,11 @@ crcResult getLoRa() {
   else { 
     if(packetSize != 0) {
       DBG("Incoming LoRa packet of " + String(packetSize) + " bytes received");
+      return CRC_NULL;
     }
   }
 return CRC_NULL;
 #endif
-}
-
-void printLoraPacket(uint8_t* p,int size) {
-  printf("Printing packet of size %d.",size);
-  for(int i = 0; i < size; i++ ) {
-    if(i % 2 == 0) printf("\n%02d: ", i);
-    printf("%02X ", p[i]);
-  }
-  printf("\n");
 }
 
 void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
@@ -302,6 +348,33 @@ void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
 #endif    // USE_LORA
 }
 
+// For now SystemPackets will not use ACK but will calculate CRC
+void transmitLoRa(uint16_t* destMAC, SystemPacket* packet, uint8_t len) {
+#ifdef USE_LORA
+  uint8_t pkt[6 + (len * sizeof(SystemPacket))];
+  uint16_t calcCRC = 0x0000;
+
+  pkt[0] = (*destMAC >> 8);
+  pkt[1] = (*destMAC & 0x00FF);
+  pkt[2] = (LoRaAddress >> 8);
+  pkt[3] = (LoRaAddress & 0x00FF);
+  memcpy(&pkt[4], packet, len * sizeof(SystemPacket));
+  for(int i = 0; i < (sizeof(pkt) - 2); i++) {  // Last 2 bytes are CRC so do not include them in the calculation itself
+    //printf("CRC: %02X : %d\n",calcCRC, i);
+    calcCRC = crc16_update(calcCRC, pkt[i]);
+  }
+  calcCRC = crc16_update(calcCRC, 0xA1); // Recalculate CRC for No ACK
+  pkt[len * sizeof(SystemPacket) + 4] = (calcCRC >> 8);
+  pkt[len * sizeof(SystemPacket) + 5] = (calcCRC & 0x00FF);
+  DBG("Transmitting LoRa message of size " + String(sizeof(pkt)) + " bytes with CRC 0x" + String(calcCRC, HEX) + " to destination 0x" + String(*destMAC, HEX));
+  //printLoraPacket(pkt,sizeof(pkt));
+  LoRa.beginPacket();
+  LoRa.write((uint8_t*)&pkt, sizeof(pkt));
+  LoRa.endPacket();
+  transmitLoRaMsg++;
+#endif    // USE_LORA
+}
+
 void sendFDRS() {
   DBG("Sending FDRS Packet!");
 #ifdef USE_ESPNOW
@@ -310,7 +383,7 @@ void sendFDRS() {
   DBG(" ESP-NOW sent.");
 #endif
 #ifdef USE_LORA
-  transmitLoRa(gtwyAddress, fdrsData, data_count);
+  transmitLoRa(&gtwyAddress, fdrsData, data_count);
   DBG(" LoRa sent.");
 #endif
   data_count = 0;
@@ -318,7 +391,7 @@ void sendFDRS() {
 }
 
 void loadFDRS(float d, uint8_t t) {
-  DBG("Id: " + String(READING_ID,16) + " - Type: " + String(t) + " - Data loaded: " + String(d));
+  DBG("Id: " + String(READING_ID, HEX) + " - Type: " + String(t) + " - Data loaded: " + String(d));
   if (data_count > espnow_size) sendFDRS();
   DataReading dr;
   dr.id = READING_ID;
@@ -344,6 +417,43 @@ void sleepFDRS(int sleep_time) {
   delay(sleep_time * 1000);
 }
 
+void pingFDRS(int timeout) {
+  SystemPacket sys_packet;
+  sys_packet.cmd = cmd_ping;
+  sys_packet.param = 0; // 0 for Ping Request and 1 for Ping Reply???
+#ifdef USE_ESPNOW
+  esp_now_send(gatewayAddress, (uint8_t *) &sys_packet, sizeof(SystemPacket));
+  DBG(" ESP-NOW ping sent.");
+  uint32_t ping_start = millis();
+  is_ping = false;
+  while ((millis() - ping_start) <= timeout) {
+    yield(); //do I need to yield or does it automatically?
+    if (is_ping) {
+      DBG("Ping Returned:" + String(millis() - ping_start));
+      is_ping = false;
+      break;
+    }
+  }
+#endif // USE_ESPNOW
+#ifdef USE_LORA
+  transmitLoRa(&gtwyAddress, &sys_packet, 1); // TODO: Make this congruent to esp_now_send()
+  DBG("LoRa ping sent to gateway address: 0x" + String(gtwyAddress, HEX));
+  uint32_t ping_start = millis();
+  is_ping = false;
+  while ((millis() - ping_start) <= timeout) {
+    getLoRa();
+    yield(); //do I need to yield or does it automatically?
+    if(is_ping) {
+      DBG("LoRa Ping Returned: " + String(millis() - ping_start) + "ms.");
+      break;
+    }
+  }
+  if(!is_ping) {
+    DBG("No LoRa ping returned within " + String(timeout) + "ms.");
+  }
+  is_ping = false;
+#endif // USE_LORA
+}
 
 // CRC16 from https://github.com/4-20ma/ModbusMaster/blob/3a05ff87677a9bdd8e027d6906dc05ca15ca8ade/src/util/crc16.h#L71
 
@@ -372,3 +482,14 @@ static uint16_t crc16_update(uint16_t crc, uint8_t a)
 
   return crc;
 }
+
+#ifdef USE_LORA
+void printLoraPacket(uint8_t* p,int size) {
+  printf("Printing packet of size %d.",size);
+  for(int i = 0; i < size; i++ ) {
+    if(i % 2 == 0) printf("\n%02d: ", i);
+    printf("%02X ", p[i]);
+  }
+  printf("\n");
+}
+#endif // USE_LORA


### PR DESCRIPTION
Added code to allow LoRa sensor send ping to LoRa gateway and receive ping reply from LoRa gateway back to the LoRa sensor via SystemPacket cmd_ping.

For the cmd_ping SystemPacket I utilized param as follows:
param = 0 is for ping request (Sensor -> Gateway for now)
param = 1 is for ping reply (Gateway -> Sensor for now)


gateway output:
```
Incoming LoRa. Size: 11 Bytes, RSSI: -45dBm, SNR: 9.00dB, PacketCRC: 0x5a77, Total LoRa received: 16, CRC Ok Pct 100.00%
We have received a ping request from 0xee42, Replying.
Transmitting LoRa message of size 11 bytes with CRC 0x6d6a to LoRa MAC 0xee42
Incoming LoRa. Size: 20 Bytes, RSSI: -44dBm, SNR: 9.50dB, PacketCRC: 0xa5d3, Total LoRa received: 17, CRC Ok Pct 100.00%
Sensor address 0xee42(hex) does not want ACK
Sending MQTT.
```

sensor output:
```
Transmitting LoRa message of size 11 bytes with CRC 0x5a77 to destination 0xee05
LoRa ping sent to gateway address: 0xee05
Incoming LoRa. Size: 11 Bytes, RSSI: -45dBm, SNR: 9.50dB, PacketCRC: 0x6d6a
We have received a ping reply via LoRa from address 0xee05
LoRa Ping Returned: 56ms.
Id: 42 - Type: 3 - Data loaded: 21.20
Id: 42 - Type: 1 - Data loaded: 42.40
Sending FDRS Packet!
Transmitting LoRa message of size 20 bytes with CRC 0xa5d3 to gateway 0xee05
 LoRa sent.
Sleepytime!
 Delaying.
```

fdrs_sensor.h is now 500 lines.
fdrs_functions.h is now 1055 lines.
Do we want to start thinking about splitting those up into different files?  Maybe LoRa stuff in it's own file for each the sensor and the gateway?   As we add capabilities the two files above are starting to look more and more similar.