### PR TITLE
Dev - sketches in examples folder of current dev branch do not compile.

### DIFF
--- a/FDRS_Gateway/fdrs_functions.h
+++ b/FDRS_Gateway/fdrs_functions.h
@@ -887,8 +887,8 @@ void begin_lora() {
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);
-  LoRa.setTxPower(LORA_TXPWR);
-  DBG("LoRa Initialized. Band: " + String(FDRS_BAND) + " SF: " + String(FDRS_SF) + " Tx Power: " + String(LORA_TXPWR) + " dBm");
+  LoRa.setTxPower(FDRS_TXPWR);
+  DBG("LoRa Initialized. Band: " + String(FDRS_BAND) + " SF: " + String(FDRS_SF) + " Tx Power: " + String(FDRS_TXPWR) + " dBm");
 #endif // USE_LORA
 }
 

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -184,8 +184,8 @@ void beginFDRS() {
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);
-  LoRa.setTxPower(LORA_TXPWR);
-  DBG("LoRa Initialized. Band: " + String(FDRS_BAND) + " SF: " + String(FDRS_SF) + " Tx Power: " + String(LORA_TXPWR) + " dBm");
+  LoRa.setTxPower(FDRS_TXPWR);
+  DBG("LoRa Initialized. Band: " + String(FDRS_BAND) + " SF: " + String(FDRS_SF) + " Tx Power: " + String(FDRS_TXPWR) + " dBm");
 #endif // USE_LORA
 #ifdef DEBUG_NODE_CONFIG
   if (resetReason != ESP_RST_DEEPSLEEP) {

--- a/FDRS_Sensor/fdrs_sensor.h
+++ b/FDRS_Sensor/fdrs_sensor.h
@@ -123,6 +123,7 @@ void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
   }
 }
 
+static uint16_t crc16_update(uint16_t, uint8_t); // function prototype for Arduino compilation purposes
 
 void beginFDRS() {
 #ifdef FDRS_DEBUG

--- a/examples/1_LoRa_Sensor/fdrs_sensor_config.h
+++ b/examples/1_LoRa_Sensor/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
+++ b/examples/2_ESPNOW_Sensor/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/3_ESPNOW_Gateway/fdrs_gateway_config.h
+++ b/examples/3_ESPNOW_Gateway/fdrs_gateway_config.h
@@ -60,9 +60,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/examples/4_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/4_UART_Gateway/fdrs_gateway_config.h
@@ -60,9 +60,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/examples/5_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/5_MQTT_Gateway/fdrs_gateway_config.h
@@ -60,9 +60,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 
 // Buffer Delays - in milliseconds - Uncomment to enable any buffer
 

--- a/examples/ESPNOW_Stress_Test/fdrs_sensor_config.h
+++ b/examples/ESPNOW_Stress_Test/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_sensor_config.h
@@ -25,9 +25,9 @@
 //433E6 for Asia
 //866E6 for Europe
 //915E6 for North America
-#define LORA_BAND 915E6     // LoRa Frequency Band
-#define LORA_SF 7           // LoRa Spreading Factor
-#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
+//#define LORA_BAND 915E6     // LoRa Frequency Band
+//#define LORA_SF 7           // LoRa Spreading Factor
+//#define LORA_TXPWR 17       // LoRa TX power in dBm (+2dBm - +20dBm), default is +17dBm.  Lower power = less battery use
 //#define LORA_ACK      // Uncomment to enable request for LoRa ACKs at cost of increased battery usage
-#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
-#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 
+//#define LORA_ACK_TIMEOUT 400   // ms timeout waiting for LoRa ACKs (if enabled).  Wouldn't go less than 200ms
+//#define LORA_RETRIES 2          // [0 - 3] When ACK enabled, number of sensor node tx retries when ACK not received or invalid CRC 

--- a/fdrs_functions.h
+++ b/fdrs_functions.h
@@ -898,8 +898,8 @@ void begin_lora() {
     DBG(" Initialization failed!");
     while (1);
   }
-  LoRa.setTxPower(LORA_TXPWR);
-  DBG("LoRa Initialized. Band: " + String(FDRS_BAND) + " SF: " + String(FDRS_SF) + " Tx Power: " + String(LORA_TXPWR) + " dBm");
+  LoRa.setTxPower(FDRS_TXPWR);
+  DBG("LoRa Initialized. Band: " + String(FDRS_BAND) + " SF: " + String(FDRS_SF) + " Tx Power: " + String(FDRS_TXPWR) + " dBm");
 #endif // USE_LORA
 }
 

--- a/fdrs_globals.h
+++ b/fdrs_globals.h
@@ -14,7 +14,7 @@
 #define GLOBAL_MQTT_ADDR "192.168.0.8"
 #define GLOBAL_MQTT_PORT 1883
 
-//#define GLOBAL_MQTT_AUTH   //Enable MQTT authentication 
+//#define GLOBAL_MQTT_AUTH   //uncomment to enable MQTT authentication  
 #define GLOBAL_MQTT_USER   "Your MQTT Username"
 #define GLOBAL_MQTT_PASS   "Your MQTT Password"
 

--- a/fdrs_sensor.h
+++ b/fdrs_sensor.h
@@ -153,8 +153,8 @@ void beginFDRS() {
     while (1);
   }
   LoRa.setSpreadingFactor(FDRS_SF);
-  LoRa.setTxPower(LORA_TXPWR);
-  DBG("LoRa Initialized. Band: " + String(FDRS_BAND) + " SF: " + String(FDRS_SF) + " Tx Power: " + String(LORA_TXPWR) + " dBm");
+  LoRa.setTxPower(FDRS_TXPWR);
+  DBG("LoRa Initialized. Band: " + String(FDRS_BAND) + " SF: " + String(FDRS_SF) + " Tx Power: " + String(FDRS_TXPWR) + " dBm");
 #endif // USE_LORA
 #ifdef DEBUG_NODE_CONFIG
   if (resetReason != ESP_RST_DEEPSLEEP) {
@@ -343,7 +343,6 @@ void sleepFDRS(int sleep_time) {
   DBG(" Delaying.");
   delay(sleep_time * 1000);
 }
-
 
 // CRC16 from https://github.com/4-20ma/ModbusMaster/blob/3a05ff87677a9bdd8e027d6906dc05ca15ca8ade/src/util/crc16.h#L71
 


### PR DESCRIPTION
Example sketches do not compile. 

I could fix some of the issues but am stuck with what is left.

Here's the compile output from Arduino IDE for this pull request:

```
In file included from D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System\examples\1_LoRa_Sensor\1_LoRa_Sensor.ino:10:0:
D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System/fdrs_sensor.h: In function 'crcResult getLoRa()':
D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System/fdrs_sensor.h:199:33: error: 'SystemPacket' was not declared in this scope
   if ((packetSize - 6) % sizeof(SystemPacket) == 0 && packetSize > 0) {  // packet size should be 6 bytes plus multiple of size of SystemPacket
                                 ^
D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System/fdrs_sensor.h:206:18: error: expected ';' before 'receiveData'
     SystemPacket receiveData[ln];
                  ^
D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System/fdrs_sensor.h:216:14: error: 'receiveData' was not declared in this scope
       memcpy(receiveData, &packet[4], packetSize - 6);   //Split off data portion of packet (N bytes)
              ^
In file included from D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System\examples\1_LoRa_Sensor\1_LoRa_Sensor.ino:10:0:
D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System/fdrs_sensor.h: In function 'void sendFDRS()':
D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System/fdrs_sensor.h:340:49: error: invalid conversion from 'uint16_t {aka short unsigned int}' to 'uint16_t* {aka short unsigned int*}' [-fpermissive]
   transmitLoRa(gtwyAddress, fdrsData, data_count);
                                                 ^
In file included from D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System\examples\1_LoRa_Sensor\1_LoRa_Sensor.ino:10:0:
D:\_sync\Sascha\OneDrive\Documents\Arduino\libraries\Farm-Data-Relay-System/fdrs_sensor.h:270:6: note:   initializing argument 1 of 'void transmitLoRa(uint16_t*, DataReading*, uint8_t)'
 void transmitLoRa(uint16_t* destMAC, DataReading * packet, uint8_t len) {
      ^
exit status 1
Fehler beim Kompilieren für das Board ESP32 Dev Module.
```

As this is only happening in the examples folder but not in the FDRS_Sensor and FDRS_Gateway folder I think it may have to do something with an order issue?

@aviateur17 can you check this? 


