### PR TITLE
2023 01 lora improvements

### DIFF
--- a/src/fdrs_gateway.h
+++ b/src/fdrs_gateway.h
@@ -41,7 +41,6 @@ DataReading theData[256];
 uint8_t ln;
 uint8_t newData = event_clear;
 uint8_t newCmd = cmd_clear;
-bool is_ping = false;
 
 DataReading fdrsData[256]; // buffer for loadFDRS()
 uint8_t data_count = 0;

--- a/src/fdrs_gateway_lora.h
+++ b/src/fdrs_gateway_lora.h
@@ -381,7 +381,7 @@ crcResult getLoRa()
           { // We have received a ping request or reply??
             if (receiveData[0].param == 1)
             { // This is a reply to our ping request
-              is_ping = true;
+              pingFlag = true;
               DBG("We have received a ping reply via LoRa from address " + String(sourceMAC, HEX));
             }
             else if (receiveData[0].param == 0)
@@ -410,7 +410,7 @@ crcResult getLoRa()
           { // We have received a ping request or reply??
             if (receiveData[0].param == 1)
             { // This is a reply to our ping request
-              is_ping = true;
+              pingFlag = true;
               DBG("We have received a ping reply via LoRa from address " + String(sourceMAC, HEX));
             }
             else if (receiveData[0].param == 0)

--- a/src/fdrs_gateway_lora.h
+++ b/src/fdrs_gateway_lora.h
@@ -84,6 +84,7 @@ RADIOLIB_MODULE radio = new Module(LORA_SS, LORA_DIO, LORA_RST, -1, LORA_SPI);
 RADIOLIB_MODULE radio = new Module(LORA_SS, LORA_DIO, LORA_RST, -1);
 #endif // CUSTOM_SPI
 
+bool pingFlag = false;
 bool transmitFlag = false;            // flag to indicate transmission or reception state
 volatile bool enableInterrupt = true; // disable interrupt when it's not needed
 volatile bool operationDone = false;  // flag to indicate that a packet was sent or received

--- a/src/fdrs_gateway_lora.h
+++ b/src/fdrs_gateway_lora.h
@@ -120,8 +120,8 @@ bool tx_time_set = false;
 #endif // USE_LORA
 
 // Function prototypes
-void transmitLoRa(uint16_t *, DataReading *, uint8_t);
-void transmitLoRa(uint16_t *, SystemPacket *, uint8_t);
+crcResult transmitLoRa(uint16_t *, DataReading *, uint8_t);
+crcResult transmitLoRa(uint16_t *, SystemPacket *, uint8_t);
 static uint16_t crc16_update(uint16_t, uint8_t);
 
 // CRC16 from https://github.com/4-20ma/ModbusMaster/blob/3a05ff87677a9bdd8e027d6906dc05ca15ca8ade/src/util/crc16.h#L71
@@ -167,8 +167,9 @@ void setFlag(void)
   operationDone = true;
 }
 
-void transmitLoRa(uint16_t *destMac, DataReading *packet, uint8_t len)
+crcResult transmitLoRa(uint16_t *destMac, DataReading *packet, uint8_t len)
 {
+  crcResult crcReturned = CRC_NULL;
   uint16_t calcCRC = 0x0000;
 
   uint8_t pkt[6 + (len * sizeof(DataReading))];
@@ -201,9 +202,12 @@ void transmitLoRa(uint16_t *destMac, DataReading *packet, uint8_t len)
     while (true)
       ;
   }
+  return crcReturned;
 }
-void transmitLoRa(uint16_t *destMac, SystemPacket *packet, uint8_t len)
+
+crcResult transmitLoRa(uint16_t *destMac, SystemPacket *packet, uint8_t len)
 {
+  crcResult crcReturned = CRC_NULL;
   uint16_t calcCRC = 0x0000;
 
   uint8_t pkt[6 + (len * sizeof(SystemPacket))];
@@ -234,6 +238,7 @@ void transmitLoRa(uint16_t *destMac, SystemPacket *packet, uint8_t len)
     while (true)
       ;
   }
+  return crcReturned;
 }
 #endif // USE_LORA
 
@@ -591,8 +596,9 @@ void asyncReleaseLoRaFirst()
   asyncReleaseLoRa(true);
 }
 
-void handleLoRa()
+crcResult handleLoRa()
 {
+  crcResult crcReturned = CRC_NULL;
   if (operationDone) // the interrupt was triggered
   {
     enableInterrupt = false;
@@ -618,7 +624,7 @@ void handleLoRa()
     }
     else // the previous operation was reception
     {
-      returnCRC = getLoRa();
+      crcReturned = getLoRa();
       if (!transmitFlag) // return to listen if no transmission was begun
       {
         radio.startReceive();
@@ -626,5 +632,6 @@ void handleLoRa()
       enableInterrupt = true;
     }
   }
+  return crcReturned;
 }
 #endif // USE_LORA

--- a/src/fdrs_node.h
+++ b/src/fdrs_node.h
@@ -51,6 +51,7 @@ uint8_t ln;
 bool newData;
 uint8_t gatewayAddress[] = {MAC_PREFIX, GTWY_MAC};
 const uint16_t espnow_size = 250 / sizeof(DataReading);
+crcResult crcReturned = CRC_NULL;
 
 uint32_t gtwy_timeout = 0;
 uint8_t incMAC[6];
@@ -355,7 +356,7 @@ bool addFDRS(int timeout, void (*new_cb_ptr)(DataReading))
   return true;
 }
 
-uint32_t pingFDRS(uint32 timeout)
+uint32_t pingFDRS(uint32_t timeout)
 {
 #ifdef USE_ESPNOW
   uint32_t pingResponseMs = pingFDRSEspNow(gatewayAddress, timeout);

--- a/src/fdrs_node.h
+++ b/src/fdrs_node.h
@@ -190,7 +190,6 @@ bool sendFDRS()
 #endif
 #ifdef USE_LORA
   transmitLoRa(&gtwyAddress, fdrsData, data_count);
-  DBG(" LoRa sent.");
   data_count = 0;
   returnCRC = CRC_NULL;
 #endif
@@ -223,7 +222,6 @@ void loadFDRS(float d, uint8_t t, uint16_t id)
 }
 void sleepFDRS(int sleep_time)
 {
-  DBG("Sleepytime!");
 #ifdef DEEP_SLEEP
   DBG(" Deep sleeping.");
 #ifdef ESP32

--- a/src/fdrs_node_espnow.h
+++ b/src/fdrs_node_espnow.h
@@ -10,9 +10,11 @@
 uint8_t broadcast_mac[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 crcResult esp_now_ack_flag;
 bool is_added = false;
-bool pingFlag = false;
+
 
 #ifdef USE_ESPNOW
+bool pingFlag = false;
+
 // Set ESP-NOW send and receive callbacks for either ESP8266 or ESP32
 #if defined(ESP8266)
 void OnDataSent(uint8_t *mac_addr, uint8_t sendStatus)
@@ -69,10 +71,10 @@ void OnDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len)
 // FDRS node pings gateway and listens for a defined amount of time for a reply
 // Blocking function for timeout amount of time (up to timeout time waiting for reply)(IE no callback)
 // Returns the amount of time in ms that the ping takes or predefined value if ping fails within timeout
-uint32_t pingFDRSEspNow(uint16_t *address, uint32_t timeout) {
+uint32_t pingFDRSEspNow(uint8_t *address, uint32_t timeout) {
     SystemPacket sys_packet = {.cmd = cmd_ping, .param = 0};
     
-    esp_now_send(gatewayAddress, (uint8_t *)&sys_packet, sizeof(SystemPacket));
+    esp_now_send(address, (uint8_t *)&sys_packet, sizeof(SystemPacket));
     DBG(" ESP-NOW ping sent.");
     uint32_t ping_start = millis();
     pingFlag = false;

--- a/src/fdrs_node_espnow.h
+++ b/src/fdrs_node_espnow.h
@@ -83,7 +83,7 @@ uint32_t pingFDRSEspNow(uint8_t *address, uint32_t timeout) {
         yield(); // do I need to yield or does it automatically?
         if (pingFlag)
         {
-            DBG("Ping Returned:" + String(millis() - ping_start) + " from " + String(incMAC[5]));
+            DBG("ESP-NOW Ping Reply in " + String(millis() - ping_start) + "ms from " + String(address[0], HEX) + ":" + String(address[1], HEX) + ":" + String(address[2], HEX) + ":" + String(address[3], HEX) + ":" + String(address[4], HEX) + ":" + String(address[5], HEX));
             return (millis() - ping_start);
         }
     }

--- a/src/fdrs_node_lora.h
+++ b/src/fdrs_node_lora.h
@@ -485,6 +485,7 @@ crcResult getLoRa()
 // Returns the amount of time in ms that the ping takes or predefined value if ping fails within timeout
 uint32_t pingFDRSLoRa(uint16_t *address, uint32_t timeout)
 {
+#ifdef USE_LORA
     SystemPacket sys_packet = {.cmd = cmd_ping, .param = 0};
 
     transmitLoRa(address, &sys_packet, 1);
@@ -504,6 +505,7 @@ uint32_t pingFDRSLoRa(uint16_t *address, uint32_t timeout)
     }
     DBG("No LoRa ping returned within " + String(timeout) + "ms.");
     return UINT32_MAX;
+#endif // USE_LORA
 }
 
 


### PR DESCRIPTION
Added PingFDRS to LoRA node code so that Node can ping gateway
Moved ESP-NOW pingFDRS code to fdrs_node_espnow since the code was split from one header file to several header files
Tweaked sleepFDRS function so that it doesn't say sleepytime since if DEEP_SLEEP is commented out the controller does not actually go to sleep.
Added crcResult return type to transmitLoRa functions so that the calling functions can actually know whether the packet was transmitted successfully and that information can be used in calling functions.   This seems to be moreso used in nodes and not so much in gateways at the current time but gateway use of crcResult return type can be developed at a later time if need be.
Used Arduino 1.8.19 to compile gateway, sensor, and controller sketches on ESP32 board type with ESP-NOW enabled and separately with LoRa enabled. 
Tweaked ESP-NOW debug message to properly include units for ping time and MAC address for ESP-NOW address being pinged.