### PR TITLE
move #ifdefs used to enable or disable features from function scope t…

### DIFF
--- a/src/fdrs_checkConfig.h
+++ b/src/fdrs_checkConfig.h
@@ -79,8 +79,8 @@ void printLoggingInformation() {
 #else
 	DBG("log buffer delay in ms: NOT SPECIFIED - check config!");
 #endif
-#ifdef FS_FILENAME
-	DBG("log filename          : " + FS_FILENAME);
+#ifdef LOG_FILENAME
+	DBG("log filename          : " + LOG_FILENAME);
 #else
 	DBG("log filename          : NOT SPECIFIED - check config!");
 #endif

--- a/src/fdrs_debug.h
+++ b/src/fdrs_debug.h
@@ -1,4 +1,3 @@
-
 #ifdef FDRS_DEBUG
 #ifdef USE_OLED
 #define DBG(a) debug_OLED(String(a)); \

--- a/src/fdrs_gateway.h
+++ b/src/fdrs_gateway.h
@@ -45,17 +45,39 @@ uint8_t newCmd = cmd_clear;
 DataReading fdrsData[256]; // buffer for loadFDRS()
 uint8_t data_count = 0;
 
-#include "fdrs_oled.h"
+// Function Prototypes needed due to #ifdefs being moved outside of function definitions in header files 
+void broadcastLoRa();
+void sendLoRaNbr(uint8_t);
+void timeFDRSLoRa(uint8_t *);
+static uint16_t crc16_update(uint16_t, uint8_t);
+void sendESPNowNbr(uint8_t);
+void sendESPNowPeers();
+void sendMQTT();
+void sendLog();
+void resendLog();
+void releaseLogBuffer();
+
+#ifdef USE_OLED
+  #include "fdrs_oled.h"
+#endif
 #include "fdrs_debug.h"
-#include "fdrs_gateway_espnow.h"
-#include "fdrs_gateway_lora.h"
-#include "fdrs_gateway_wifi.h"
-#include "fdrs_gateway_filesystem.h"
-#include "fdrs_gateway_mqtt.h"
 #include "fdrs_gateway_serial.h"
 #include "fdrs_gateway_scheduler.h"
+#ifdef USE_ESPNOW
+  #include "fdrs_gateway_espnow.h"
+#endif
+#ifdef USE_LORA
+  #include "fdrs_gateway_lora.h"
+#endif
+#ifdef USE_WIFI
+  #include "fdrs_gateway_wifi.h"
+  #include "fdrs_gateway_mqtt.h"
+#endif
+#if defined(USE_FS_LOG) || defined(USE_SD_LOG)
+  #include "fdrs_gateway_filesystem.h"
+#endif
 #ifdef DEBUG_CONFIG
-#include "fdrs_checkConfig.h"
+  #include "fdrs_checkConfig.h"
 #endif
 
 void sendFDRS()
@@ -193,3 +215,16 @@ void loopFDRS()
   }
 }
 
+// "Skeleton Functions related to FDRS Actions"
+#ifndef USE_LORA
+  void broadcastLoRa() {}
+  void sendLoRaNbr(uint8_t address) {}
+  void timeFDRSLoRa(uint8_t *address) {}
+#endif
+#ifndef USE_ESPNOW
+  void sendESPNowNbr(uint8_t interface) {}
+  void sendESPNowPeers() {}
+#endif
+#ifndef USE_WIFI
+  void sendMQTT() {}
+#endif

--- a/src/fdrs_gateway_espnow.h
+++ b/src/fdrs_gateway_espnow.h
@@ -18,11 +18,11 @@ esp_now_peer_info_t peerInfo;
 const uint8_t broadcast_mac[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 const uint8_t mac_prefix[] = {MAC_PREFIX};
-const uint8_t selfAddress[] = {MAC_PREFIX, UNIT_MAC};
+uint8_t selfAddress[] = {MAC_PREFIX, UNIT_MAC};
 uint8_t incMAC[6];
 
-const uint8_t ESPNOW1[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_1};
-const uint8_t ESPNOW2[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_2};
+uint8_t ESPNOW1[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_1};
+uint8_t ESPNOW2[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_2};
 
 
 // Set ESP-NOW send and receive callbacks for either ESP8266 or ESP32

--- a/src/fdrs_gateway_espnow.h
+++ b/src/fdrs_gateway_espnow.h
@@ -15,16 +15,16 @@ const uint8_t espnow_size = 250 / sizeof(DataReading);
 esp_now_peer_info_t peerInfo;
 #endif
 
-uint8_t broadcast_mac[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+const uint8_t broadcast_mac[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 const uint8_t mac_prefix[] = {MAC_PREFIX};
-uint8_t selfAddress[] = {MAC_PREFIX, UNIT_MAC};
+const uint8_t selfAddress[] = {MAC_PREFIX, UNIT_MAC};
 uint8_t incMAC[6];
 
-uint8_t ESPNOW1[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_1};
-uint8_t ESPNOW2[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_2};
+const uint8_t ESPNOW1[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_1};
+const uint8_t ESPNOW2[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_2};
 
-#ifdef USE_ESPNOW
+
 // Set ESP-NOW send and receive callbacks for either ESP8266 or ESP32
 #if defined(ESP8266)
 void OnDataSent(uint8_t *mac_addr, uint8_t sendStatus)
@@ -62,11 +62,9 @@ void OnDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len)
   }
   newData = event_espnowg;
 }
-#endif // USE_ESPNOW
 
 void begin_espnow()
 {
-#ifdef USE_ESPNOW
   DBG("Initializing ESP-NOW!");
   WiFi.mode(WIFI_STA);
   WiFi.disconnect();
@@ -110,10 +108,7 @@ void begin_espnow()
   }
 #endif // ESP8266
   DBG(" ESP-NOW Initialized.");
-#endif // USE_ESPNOW
 }
-
-#ifdef USE_ESPNOW
 
 // Returns an expired entry in peer_list, -1 if full.
 int find_espnow_peer()
@@ -228,86 +223,81 @@ void pingback_espnow()
     esp_now_send(incMAC, (uint8_t *)&sys_packet, sizeof(SystemPacket));
   }
 }
-#endif // USE_ESPNOW
 
 void sendESPNowNbr(uint8_t interface)
 {
-#ifdef USE_ESPNOW
   switch (interface)
   {
-  case 1:
-  { // These brackets are required!
-    DBG("Sending to ESP-NOW Neighbor #1");
+    case 1:
+    { // These brackets are required!
+      DBG("Sending to ESP-NOW Neighbor #1");
 #if defined(ESP32)
-    esp_now_peer_info_t peerInfo;
-    peerInfo.ifidx = WIFI_IF_STA;
-    peerInfo.channel = 0;
-    peerInfo.encrypt = false;
-    memcpy(peerInfo.peer_addr, ESPNOW1, 6);
-    if (esp_now_add_peer(&peerInfo) != ESP_OK)
-    {
-      DBG("Failed to add peer");
-      return;
-    }
-#endif // ESP32
-    DataReading thePacket[ln];
-    int j = 0;
-
-    for (int i = 0; i < ln; i++)
-    {
-      if (j > espnow_size)
+      esp_now_peer_info_t peerInfo;
+      peerInfo.ifidx = WIFI_IF_STA;
+      peerInfo.channel = 0;
+      peerInfo.encrypt = false;
+      memcpy(peerInfo.peer_addr, ESPNOW1, 6);
+      if (esp_now_add_peer(&peerInfo) != ESP_OK)
       {
-        j = 0;
-        esp_now_send(ESPNOW1, (uint8_t *)&thePacket, sizeof(thePacket));
+        DBG("Failed to add peer");
+        return;
       }
-      thePacket[j] = theData[i];
-      j++;
-    }
-    esp_now_send(ESPNOW1, (uint8_t *)&thePacket, j * sizeof(DataReading));
-    esp_now_del_peer(ESPNOW1);
+#endif // ESP32
+      DataReading thePacket[ln];
+      int j = 0;
 
-    break;
-  } // These brackets are required!
-  case 2:
-  {
-    DBG("Sending to ESP-NOW Neighbor #2");
+      for (int i = 0; i < ln; i++)
+      {
+        if (j > espnow_size)
+        {
+          j = 0;
+          esp_now_send(ESPNOW1, (uint8_t *)&thePacket, sizeof(thePacket));
+        }
+        thePacket[j] = theData[i];
+        j++;
+      }
+      esp_now_send(ESPNOW1, (uint8_t *)&thePacket, j * sizeof(DataReading));
+      esp_now_del_peer(ESPNOW1);
+
+      break;
+    } // These brackets are required!
+    case 2:
+    {
+      DBG("Sending to ESP-NOW Neighbor #2");
 #if defined(ESP32)
-    esp_now_peer_info_t peerInfo;
-    peerInfo.ifidx = WIFI_IF_STA;
-    peerInfo.channel = 0;
-    peerInfo.encrypt = false;
-    memcpy(peerInfo.peer_addr, ESPNOW2, 6);
-    if (esp_now_add_peer(&peerInfo) != ESP_OK)
-    {
-      DBG("Failed to add peer");
-      return;
-    }
-#endif // ESP32
-    DataReading thePacket[ln];
-    int j = 0;
-    for (int i = 0; i < ln; i++)
-    {
-      if (j > espnow_size)
+      esp_now_peer_info_t peerInfo;
+      peerInfo.ifidx = WIFI_IF_STA;
+      peerInfo.channel = 0;
+      peerInfo.encrypt = false;
+      memcpy(peerInfo.peer_addr, ESPNOW2, 6);
+      if (esp_now_add_peer(&peerInfo) != ESP_OK)
       {
-        j = 0;
-        esp_now_send(ESPNOW2, (uint8_t *)&thePacket, sizeof(thePacket));
+        DBG("Failed to add peer");
+        return;
       }
-      thePacket[j] = theData[i];
-      j++;
+#endif // ESP32
+      DataReading thePacket[ln];
+      int j = 0;
+      for (int i = 0; i < ln; i++)
+      {
+        if (j > espnow_size)
+        {
+          j = 0;
+          esp_now_send(ESPNOW2, (uint8_t *)&thePacket, sizeof(thePacket));
+        }
+        thePacket[j] = theData[i];
+        j++;
+      }
+      esp_now_send(ESPNOW2, (uint8_t *)&thePacket, j * sizeof(DataReading));
+      esp_now_del_peer(ESPNOW2);
+
+      break;
     }
-    esp_now_send(ESPNOW2, (uint8_t *)&thePacket, j * sizeof(DataReading));
-    esp_now_del_peer(ESPNOW2);
-
-    break;
   }
-  }
-
-#endif // USE_ESPNOW
 }
 
 void sendESPNowPeers()
 {
-#ifdef USE_ESPNOW
   DBG("Sending to ESP-NOW peers.");
   DataReading thePacket[ln];
   int j = 0;
@@ -322,12 +312,10 @@ void sendESPNowPeers()
     j++;
   }
   esp_now_send(0, (uint8_t *)&thePacket, j * sizeof(DataReading));
-#endif // USE_ESPNOW
 }
 
 void sendESPNow(uint8_t address)
 {
-#ifdef USE_ESPNOW
   DBG("Sending ESP-NOW.");
   uint8_t temp_peer[] = {MAC_PREFIX, address};
 #if defined(ESP32)
@@ -358,6 +346,4 @@ void sendESPNow(uint8_t address)
 
   esp_now_send(temp_peer, (uint8_t *)&thePacket, j * sizeof(DataReading));
   esp_now_del_peer(temp_peer);
-
-#endif // USE_ESPNOW
 }

--- a/src/fdrs_gateway_lora.h
+++ b/src/fdrs_gateway_lora.h
@@ -1,4 +1,3 @@
-#ifdef USE_LORA
 #include <RadioLib.h>
 
 #define GLOBAL_ACK_TIMEOUT 400 // LoRa ACK timeout in ms. (Minimum = 200)
@@ -84,6 +83,11 @@ RADIOLIB_MODULE radio = new Module(LORA_SS, LORA_DIO, LORA_RST, -1, LORA_SPI);
 RADIOLIB_MODULE radio = new Module(LORA_SS, LORA_DIO, LORA_RST, -1);
 #endif // CUSTOM_SPI
 
+#ifndef USE_ESPNOW   // mac_prefix used for both ESP-NOW and LoRa - avoid redefinition warnings
+  const uint8_t mac_prefix[] = {MAC_PREFIX};
+  const uint8_t selfAddress[] = {MAC_PREFIX, UNIT_MAC};
+#endif
+
 bool pingFlag = false;
 bool transmitFlag = false;            // flag to indicate transmission or reception state
 volatile bool enableInterrupt = true; // disable interrupt when it's not needed
@@ -118,12 +122,26 @@ uint8_t tx_buffer_position = 0;
 uint32_t tx_start_time;
 bool tx_time_set = false;
 
-#endif // USE_LORA
-
 // Function prototypes
 crcResult transmitLoRa(uint16_t *, DataReading *, uint8_t);
 crcResult transmitLoRa(uint16_t *, SystemPacket *, uint8_t);
 static uint16_t crc16_update(uint16_t, uint8_t);
+
+#if defined(ESP8266) || defined(ESP32)
+ICACHE_RAM_ATTR
+#endif
+void setFlag(void)
+{
+  // check if the interrupt is enabled
+  if (!enableInterrupt)
+  {
+    return;
+  }
+  // we sent or received  packet, set the flag
+  operationDone = true;
+}
+
+// crc16_update used by both LoRa and filesystem
 
 // CRC16 from https://github.com/4-20ma/ModbusMaster/blob/3a05ff87677a9bdd8e027d6906dc05ca15ca8ade/src/util/crc16.h#L71
 
@@ -151,21 +169,6 @@ static uint16_t crc16_update(uint16_t crc, uint8_t a)
   }
 
   return crc;
-}
-#ifdef USE_LORA
-
-#if defined(ESP8266) || defined(ESP32)
-ICACHE_RAM_ATTR
-#endif
-void setFlag(void)
-{
-  // check if the interrupt is enabled
-  if (!enableInterrupt)
-  {
-    return;
-  }
-  // we sent or received  packet, set the flag
-  operationDone = true;
 }
 
 crcResult transmitLoRa(uint16_t *destMac, DataReading *packet, uint8_t len)
@@ -242,7 +245,6 @@ crcResult transmitLoRa(uint16_t *destMac, SystemPacket *packet, uint8_t len)
   }
   return crcReturned;
 }
-#endif // USE_LORA
 
 void printLoraPacket(uint8_t *p, int size)
 {
@@ -256,7 +258,6 @@ void printLoraPacket(uint8_t *p, int size)
   printf("\n");
 }
 
-#ifdef USE_LORA
 void begin_lora()
 {
 #ifdef CUSTOM_SPI
@@ -296,11 +297,9 @@ void begin_lora()
       ;
   }
 }
-#endif // USE_LORA
 
 crcResult getLoRa()
 {
-#ifdef USE_LORA
 
   int packetSize = radio.getPacketLength();
   if ((((packetSize - 6) % sizeof(DataReading) == 0) || ((packetSize - 6) % sizeof(SystemPacket) == 0)) && packetSize > 0)
@@ -460,14 +459,12 @@ crcResult getLoRa()
       return CRC_NULL;
     }
   }
-#endif // USE_LORA
   return CRC_NULL;
 }
 
 // Sends packet to any node that is paired to this gateway
 void broadcastLoRa()
 {
-#ifdef USE_LORA
   DBG("Sending to LoRa broadcast buffer");
 
   for (int i = 0; i < ln; i++)
@@ -475,14 +472,11 @@ void broadcastLoRa()
     LORABBuffer.buffer[LORABBuffer.len + i] = theData[i];
   }
   LORABBuffer.len += ln;
-
-#endif // USE_LORA
 }
 
 // Sends packet to neighbor gateways
 void sendLoRaNbr(uint8_t interface)
 {
-#ifdef USE_LORA
   DBG("Sending to LoRa neighbor buffer");
   switch (interface)
   {
@@ -505,9 +499,7 @@ void sendLoRaNbr(uint8_t interface)
     break;
   }
   }
-#endif // USE_LORA
 }
-#ifdef USE_LORA
 
 void asyncReleaseLoRa(bool first_run)
 {
@@ -593,6 +585,7 @@ void asyncReleaseLoRa(bool first_run)
     }
   }
 }
+
 void asyncReleaseLoRaFirst()
 {
   asyncReleaseLoRa(true);
@@ -636,4 +629,3 @@ crcResult handleLoRa()
   }
   return crcReturned;
 }
-#endif // USE_LORA

--- a/src/fdrs_gateway_mqtt.h
+++ b/src/fdrs_gateway_mqtt.h
@@ -1,4 +1,3 @@
-#ifdef USE_WIFI
 #include <PubSubClient.h>
 #include <ArduinoJson.h>
 
@@ -41,11 +40,17 @@
 #define FDRS_MQTT_AUTH
 #endif // MQTT_AUTH
 
+
 WiFiClient espClient;
 PubSubClient client(espClient);
 
 const char *mqtt_server = FDRS_MQTT_ADDR;
 const int mqtt_port = FDRS_MQTT_PORT;
+#if defined(USE_SD_LOG) || defined(USE_FS_LOG)
+    extern time_t last_log_write;
+    extern time_t last_mqtt_success;
+#endif
+
 
 #ifdef FDRS_MQTT_AUTH
 const char *mqtt_user = FDRS_MQTT_USER;
@@ -152,7 +157,9 @@ void mqtt_publish(const char *payload)
     if (!client.publish(TOPIC_DATA, payload))
     {
         DBG(" Error on sending MQTT");
+#if defined(USE_SD_LOG) || defined(USE_FS_LOG)
         sendLog();
+#endif
     }
     else
     {
@@ -166,11 +173,9 @@ void mqtt_publish(const char *payload)
 #endif
     }
 }
-#endif // USE_WIFI
 
 void sendMQTT()
 {
-#ifdef USE_WIFI
     DBG("Sending MQTT.");
     DynamicJsonDocument doc(24576);
     for (int i = 0; i < ln; i++)
@@ -183,5 +188,4 @@ void sendMQTT()
     String outgoingString;
     serializeJson(doc, outgoingString);
     mqtt_publish((char *)outgoingString.c_str());
-#endif // USE_WIFI
 }

--- a/src/fdrs_gateway_wifi.h
+++ b/src/fdrs_gateway_wifi.h
@@ -4,7 +4,6 @@
 #endif
 #endif // USE_ETHERNET
 
-#ifdef USE_WIFI
 #include <WiFiUdp.h>
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
@@ -97,4 +96,3 @@ void begin_wifi()
   }
 #endif // USE_ETHERNET
 }
-#endif // USE_WIFI

--- a/src/fdrs_globals.h
+++ b/src/fdrs_globals.h
@@ -17,7 +17,8 @@
 // MQTT Topics
 #define TOPIC_DATA    "fdrs/data"
 #define TOPIC_STATUS  "fdrs/status"
-#define TOPIC_COMMAND "fdrs/command" 
+#define TOPIC_COMMAND "fdrs/command"
+#define TOPIC_DATA_BACKLOG "fdrs/databacklog"   // Used in filesystem module
 
 #define GLOBAL_LORA_FREQUENCY 915.0   // Carrier frequency in MHz. Allowed values range from 137.0 MHz to 1020.0 MHz (varies by chip).
 #define GLOBAL_LORA_SF 7     // LoRa link spreading factor. Allowed values range from 6 to 12.

--- a/src/fdrs_node.h
+++ b/src/fdrs_node.h
@@ -36,10 +36,6 @@ static uint16_t crc16_update(uint16_t crc, uint8_t a)
   return crc;
 }
 
-#ifdef DEBUG_CONFIG
-// #include "fdrs_checkConfig.h"
-#endif
-
 SystemPacket theCmd;
 DataReading theData[256];
 uint8_t ln;
@@ -60,10 +56,19 @@ void (*callback_ptr)(DataReading);
 uint16_t subscription_list[256] = {};
 bool active_subs[256] = {};
 
-#include "fdrs_oled.h"
 #include "fdrs_debug.h"
-#include "fdrs_node_espnow.h"
-#include "fdrs_node_lora.h"
+#ifdef DEBUG_CONFIG
+// #include "fdrs_checkConfig.h"
+#endif
+#ifdef USE_OLED
+  #include "fdrs_oled.h"
+#endif
+#ifdef USE_ESPNOW
+  #include "fdrs_node_espnow.h"
+#endif
+#ifdef USE_LORA
+  #include "fdrs_node_lora.h"
+#endif
 
 void beginFDRS()
 {
@@ -139,7 +144,9 @@ void beginFDRS()
 #endif
   DBG(" ESP-NOW Initialized.");
 #endif // USE_ESPNOW
+#ifdef USE_LORA
   begin_lora();
+#endif
 #ifdef DEBUG_CONFIG
   // if (resetReason != ESP_RST_DEEPSLEEP) {
   // checkConfig();
@@ -259,7 +266,9 @@ void sleepFDRS(int sleep_time)
 
 void loopFDRS()
 {
+#ifdef USE_LORA
   handleLoRa();
+#endif
   handleIncoming();
   // // TO-DO:
   // if (is_added)

--- a/src/fdrs_node_espnow.h
+++ b/src/fdrs_node_espnow.h
@@ -1,18 +1,15 @@
 #if defined(ESP8266)
-#include <ESP8266WiFi.h>
-#include <espnow.h>
+    #include <ESP8266WiFi.h>
+    #include <espnow.h>
 #elif defined(ESP32)
-#include <esp_now.h>
-#include <WiFi.h>
-#include <esp_wifi.h>
+    #include <esp_now.h>
+    #include <WiFi.h>
+    #include <esp_wifi.h>
 #endif
 
 uint8_t broadcast_mac[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 crcResult esp_now_ack_flag;
 bool is_added = false;
-
-
-#ifdef USE_ESPNOW
 bool pingFlag = false;
 
 // Set ESP-NOW send and receive callbacks for either ESP8266 or ESP32
@@ -90,5 +87,3 @@ uint32_t pingFDRSEspNow(uint8_t *address, uint32_t timeout) {
     DBG("No ESP-NOW ping returned within " + String(timeout) + "ms.");
     return UINT32_MAX;
 }
-
-#endif // USE_ESPNOW

--- a/src/fdrs_node_lora.h
+++ b/src/fdrs_node_lora.h
@@ -1,7 +1,6 @@
-#ifdef USE_LORA
+
 #include <ArduinoUniqueID.h>
 #include <RadioLib.h>
-#endif
 
 // Internal Globals
 // Default values: overridden by settings in config, if present
@@ -10,7 +9,6 @@
 #define GLOBAL_LORA_RETRIES 2  // LoRa ACK automatic retries [0 - 3]
 #define GLOBAL_LORA_TXPWR 17   // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 
-#ifdef USE_LORA
 // select LoRa band configuration
 #if defined(LORA_FREQUENCY)
 #define FDRS_LORA_FREQUENCY LORA_FREQUENCY
@@ -111,11 +109,9 @@ void setFlag(void)
     }
     operationDone = true; // we sent or received  packet, set the flag
 }
-#endif // USE_LORA
 
 crcResult handleLoRa()
 {
-#ifdef USE_LORA
     crcResult crcReturned = CRC_NULL;
     if (operationDone)
     { // the interrupt was triggered
@@ -138,14 +134,11 @@ crcResult handleLoRa()
             enableInterrupt = true;
         }
     }
-#endif // USE_LORA
     return crcReturned;
 }
 
 void begin_lora()
 {
-
-#ifdef USE_LORA
 #ifdef CUSTOM_SPI
 #ifdef ESP32
     LORA_SPI.begin(LORA_SPI_SCK, LORA_SPI_MISO, LORA_SPI_MOSI);
@@ -183,7 +176,6 @@ void begin_lora()
         while (true)
             ;
     }
-#endif // USE_LORA
 }
 
 // Transmits Lora data by calling RadioLib library function
@@ -191,7 +183,6 @@ void begin_lora()
 
 crcResult transmitLoRa(uint16_t *destMAC, DataReading *packet, uint8_t len)
 {
-#ifdef USE_LORA
     crcResult crcReturned = CRC_NULL;
     uint8_t pkt[6 + (len * sizeof(DataReading))];
     uint16_t calcCRC = 0x0000;
@@ -276,7 +267,6 @@ crcResult transmitLoRa(uint16_t *destMAC, DataReading *packet, uint8_t len)
     }
     transmitLoRaMsgwAck++;
 #endif // LORA_ACK
-#endif // USE_LORA
     return crcReturned;
 }
 
@@ -284,7 +274,6 @@ crcResult transmitLoRa(uint16_t *destMAC, DataReading *packet, uint8_t len)
 // Returns CRC_NULL ask SystemPackets do not use ACKS at current time
 crcResult transmitLoRa(uint16_t *destMAC, SystemPacket *packet, uint8_t len)
 {
-#ifdef USE_LORA
     crcResult crcReturned = CRC_NULL;
     uint8_t pkt[6 + (len * sizeof(SystemPacket))];
     uint16_t calcCRC = 0x0000;
@@ -321,7 +310,6 @@ crcResult transmitLoRa(uint16_t *destMAC, SystemPacket *packet, uint8_t len)
         while (true)
             ;
     }
-#endif // USE_LORA
     return crcReturned;
 }
 
@@ -332,7 +320,6 @@ crcResult transmitLoRa(uint16_t *destMAC, SystemPacket *packet, uint8_t len)
 
 crcResult getLoRa()
 {
-#ifdef USE_LORA
     int packetSize = radio.getPacketLength();
     if ((((packetSize - 6) % sizeof(DataReading) == 0) || ((packetSize - 6) % sizeof(SystemPacket) == 0)) && packetSize > 0)
     { // packet size should be 6 bytes plus multiple of size of DataReading
@@ -480,7 +467,6 @@ crcResult getLoRa()
             return CRC_NULL;
         }
     }
-#endif // USE_LORA
     return CRC_NULL;
 }
 
@@ -489,7 +475,6 @@ crcResult getLoRa()
 // Returns the amount of time in ms that the ping takes or predefined value if ping fails within timeout
 uint32_t pingFDRSLoRa(uint16_t *address, uint32_t timeout)
 {
-#ifdef USE_LORA
     SystemPacket sys_packet = {.cmd = cmd_ping, .param = 0};
 
     transmitLoRa(address, &sys_packet, 1);
@@ -508,7 +493,6 @@ uint32_t pingFDRSLoRa(uint16_t *address, uint32_t timeout)
         }
     }
     DBG("No LoRa ping returned within " + String(timeout) + "ms.");
-#endif // USE_LORA
     return UINT32_MAX;
 }
 

--- a/src/fdrs_oled.h
+++ b/src/fdrs_oled.h
@@ -1,5 +1,5 @@
 
-#ifdef USE_OLED
+
 #include <ESP8266_and_ESP32_OLED_driver_for_SSD1306_displays/src/SSD1306Wire.h>
 
 String debug_buffer[5] = {"", "", "", "", ""};
@@ -69,4 +69,3 @@ void init_oled(){
 
 
   }
-#endif


### PR DESCRIPTION
…o file scope

Takes the #ifdefs used to disable and enable features like filesystem logging, ESP-NOW, LoRa, Debug, WiFi, etc. from function by function to including or excluding entire header files thus being a cleaner or more straightforward and simpler approach.