### PR TITLE
FDRS OLED features

### DIFF
--- a/examples/0_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/0_MQTT_Gateway/fdrs_gateway_config.h
@@ -46,6 +46,7 @@
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    
 #define OLED_HEADER "FDRS"
+#define OLED_PAGE_SECS 30
 #define OLED_SDA 4
 #define OLED_SCL 15
 #define OLED_RST 16

--- a/examples/1_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/1_UART_Gateway/fdrs_gateway_config.h
@@ -46,6 +46,7 @@
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    
 #define OLED_HEADER "FDRS"
+#define OLED_PAGE_SECS 30
 #define OLED_SDA 4
 #define OLED_SCL 15
 #define OLED_RST 16

--- a/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
+++ b/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
@@ -46,6 +46,7 @@
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    
 #define OLED_HEADER "FDRS"
+#define OLED_PAGE_SECS 30
 #define OLED_SDA 4
 #define OLED_SCL 15
 #define OLED_RST 16

--- a/examples/3_LoRa_Repeater/fdrs_gateway_config.h
+++ b/examples/3_LoRa_Repeater/fdrs_gateway_config.h
@@ -46,6 +46,7 @@
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    
 #define OLED_HEADER "FDRS"
+#define OLED_PAGE_SECS 30
 #define OLED_SDA 4
 #define OLED_SCL 15
 #define OLED_RST 16

--- a/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
@@ -46,6 +46,7 @@
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    
 #define OLED_HEADER "FDRS"
+#define OLED_PAGE_SECS 30
 #define OLED_SDA 4
 #define OLED_SCL 15
 #define OLED_RST 16

--- a/src/fdrs_gateway.h
+++ b/src/fdrs_gateway.h
@@ -179,6 +179,9 @@ void loopFDRS()
 #ifdef USE_WIFI
   handleMQTT();
 #endif
+#ifdef USE_OLED
+  drawPageOLED(true);
+#endif
   if (newData != event_clear)
   {
     switch (newData)

--- a/src/fdrs_oled.h
+++ b/src/fdrs_oled.h
@@ -1,9 +1,12 @@
 
 
 #include <ESP8266_and_ESP32_OLED_driver_for_SSD1306_displays/src/SSD1306Wire.h>
+#define DISPLAY_PAGES 4
 
 String debug_buffer[5] = {"", "", "", "", ""};
 SSD1306Wire display(0x3c, OLED_SDA, OLED_SCL); // ADDRESS, SDA, SCL
+unsigned long displayEvent = 0;
+uint8_t displayPage = 0;
 
 void draw_OLED_header()
 {
@@ -33,20 +36,12 @@ void draw_OLED_header()
     display.setTextAlignment(TEXT_ALIGN_LEFT);
     display.setFont(ArialMT_Plain_10);
     #endif
-}
-
-void debug_OLED(String debug_text)
-{
-    draw_OLED_header();
     display.drawHorizontalLine(0, 15, 128);
     display.drawHorizontalLine(0, 16, 128);
+}
 
-    for (uint8_t i = 4; i > 0; i--)
-    {
-
-        debug_buffer[i] = debug_buffer[i - 1];
-    }
-    debug_buffer[0] = String(millis() / 1000) + " " + debug_text;
+void drawDebugPage() {
+    draw_OLED_header();
     uint8_t lineNumber = 0;
     for (uint8_t i = 0; i < 5; i++)
     {
@@ -57,6 +52,86 @@ void debug_OLED(String debug_text)
     }
     display.display();
 }
+
+void debug_OLED(String debug_text)
+{
+    displayEvent = millis()/1000; // Display Event is tracked in units of seconds
+    displayPage = 0;
+    display.clear();
+
+    for (uint8_t i = 4; i > 0; i--)
+    {
+
+        debug_buffer[i] = debug_buffer[i - 1];
+    }
+    debug_buffer[0] = String(millis() / 1000) + " " + debug_text;
+    drawDebugPage();
+}
+
+void drawBlankPage() {
+    display.clear();
+    display.display();
+}
+
+void drawStatusPage() {
+    // draw_OLED_header();
+    // display.FDRS_drawStringMaxWidth(0, 17, 127, "Status Page 1 " + String(millis()/1000));
+    // display.display();
+}
+
+void drawPage2() {
+    // draw_OLED_header();
+    // display.FDRS_drawStringMaxWidth(0, 17, 127, "Page 2 " + String(millis()/1000));
+    // display.display();
+}
+
+void drawPage3() {
+    // draw_OLED_header();
+    // display.FDRS_drawStringMaxWidth(0, 17, 127, "Page 3 " + String(millis()/1000));
+    // display.display();
+}
+
+// write display content to display buffer
+// nextpage = true -> flip 1 page
+// When debug info comes in then switch to debug page
+// after 60 seconds switch to blank page to save screen
+void drawPageOLED(bool nextpage) {
+
+    if((millis()/1000 - displayEvent) > OLED_PAGE_SECS && nextpage) {
+        displayPage = (displayPage >= DISPLAY_PAGES) ? 0 : (displayPage + 1);
+        displayEvent = millis()/1000;
+        display.clear();
+
+        switch(displayPage) {
+
+        // page 0: debug output
+        // page 1: gateway/node status
+        // page 2: to be defined
+        // page 3: to be defined
+        // page 4: blank (screen saver)
+
+        case 0: // display debug output
+            drawDebugPage();
+            break;
+        case 1: // gateway/node status
+            // drawStatusPage();
+            // break;
+        case 2: // to be defined later
+            // drawPage2();
+            // break;
+        case 3: // to be defined later
+            // drawPage3();
+            // break;
+        case 4: // Blank page
+            drawBlankPage();
+            break;
+        default: // Blank page
+            drawBlankPage();
+            break;
+        }
+    }
+}
+
 void init_oled(){
   pinMode(OLED_RST, OUTPUT);
   digitalWrite(OLED_RST, LOW);
@@ -66,6 +141,4 @@ void init_oled(){
   display.init();
   display.flipScreenVertically();
   draw_OLED_header();
-
-
   }


### PR DESCRIPTION
Add OLED 'pages' and blank OLED screen

Adding "paging" feature to OLED such that different sets of data can be shown.  First page will be standard debug data.  Rest of pages will be defined later.  #define in config file states how long each page will stay on screen (default 30 seconds).  When any debug information is added screen immediately switches to that debug screen until there is no action for a specified amount of time (default 30 seconds).