### PR TITLE
Update fdrs_node_lora.h

### DIFF
--- a/src/fdrs_node_lora.h
+++ b/src/fdrs_node_lora.h
@@ -494,8 +494,8 @@ uint32_t pingFDRSLoRa(uint16_t *address, uint32_t timeout)
     while ((millis() - ping_start) <= timeout)
     {
         handleLoRa();
-        #ifdef ESP8266  // yeild appears to be only needed by the ESP8266 MCUs
-            yield(); // do I need to yield or does it automatically?
+        #ifdef ESP8266
+            yield();
         #endif
         if (pingFlag)
         {

--- a/src/fdrs_node_lora.h
+++ b/src/fdrs_node_lora.h
@@ -494,7 +494,9 @@ uint32_t pingFDRSLoRa(uint16_t *address, uint32_t timeout)
     while ((millis() - ping_start) <= timeout)
     {
         handleLoRa();
-        yield(); // do I need to yield or does it automatically?
+        #ifdef ESP8266  // yeild appears to be only needed by the ESP8266 MCUs
+            yield(); // do I need to yield or does it automatically?
+        #endif
         if (pingFlag)
         {
             DBG("LoRa Ping Returned: " + String(millis() - ping_start) + "ms.");


### PR DESCRIPTION
Wrap 'yield();' in '#ifdef ESP8266' as it does not appear to be needed by any other MCUs