### PR TITLE
Feature add: FDRS logging verbosity

### DIFF
--- a/examples/0_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/0_MQTT_Gateway/fdrs_gateway_config.h
@@ -43,7 +43,11 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/0_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/0_MQTT_Gateway/fdrs_gateway_config.h
@@ -44,7 +44,7 @@
 #define LORA_SPI_MOSI 27
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/0_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/0_MQTT_Gateway/fdrs_gateway_config.h
@@ -46,8 +46,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/0_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/0_MQTT_Gateway/fdrs_gateway_config.h
@@ -43,11 +43,8 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/1_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/1_UART_Gateway/fdrs_gateway_config.h
@@ -43,7 +43,11 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/1_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/1_UART_Gateway/fdrs_gateway_config.h
@@ -44,7 +44,7 @@
 #define LORA_SPI_MOSI 27
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/1_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/1_UART_Gateway/fdrs_gateway_config.h
@@ -46,8 +46,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/1_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/1_UART_Gateway/fdrs_gateway_config.h
@@ -43,11 +43,8 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
+++ b/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
@@ -43,7 +43,11 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
+++ b/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
@@ -44,7 +44,7 @@
 #define LORA_SPI_MOSI 27
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
+++ b/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
@@ -46,8 +46,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
+++ b/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
@@ -43,11 +43,8 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/3_LoRa_Repeater/fdrs_gateway_config.h
+++ b/examples/3_LoRa_Repeater/fdrs_gateway_config.h
@@ -43,7 +43,11 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/3_LoRa_Repeater/fdrs_gateway_config.h
+++ b/examples/3_LoRa_Repeater/fdrs_gateway_config.h
@@ -44,7 +44,7 @@
 #define LORA_SPI_MOSI 27
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/3_LoRa_Repeater/fdrs_gateway_config.h
+++ b/examples/3_LoRa_Repeater/fdrs_gateway_config.h
@@ -46,8 +46,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/3_LoRa_Repeater/fdrs_gateway_config.h
+++ b/examples/3_LoRa_Repeater/fdrs_gateway_config.h
@@ -43,11 +43,8 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/Controller_examples/FastLED/fdrs_node_config.h
+++ b/examples/Controller_examples/FastLED/fdrs_node_config.h
@@ -11,7 +11,12 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/FastLED/fdrs_node_config.h
+++ b/examples/Controller_examples/FastLED/fdrs_node_config.h
@@ -15,8 +15,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/FastLED/fdrs_node_config.h
+++ b/examples/Controller_examples/FastLED/fdrs_node_config.h
@@ -12,11 +12,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/FastLED/fdrs_node_config.h
+++ b/examples/Controller_examples/FastLED/fdrs_node_config.h
@@ -13,7 +13,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/Irrigation/fdrs_node_config.h
+++ b/examples/Controller_examples/Irrigation/fdrs_node_config.h
@@ -15,8 +15,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/Irrigation/fdrs_node_config.h
+++ b/examples/Controller_examples/Irrigation/fdrs_node_config.h
@@ -11,7 +11,12 @@
 //#define USE_LORA
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/Irrigation/fdrs_node_config.h
+++ b/examples/Controller_examples/Irrigation/fdrs_node_config.h
@@ -12,11 +12,8 @@
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/Irrigation/fdrs_node_config.h
+++ b/examples/Controller_examples/Irrigation/fdrs_node_config.h
@@ -13,7 +13,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
+++ b/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
@@ -15,8 +15,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
+++ b/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
@@ -11,7 +11,12 @@
 //#define USE_LORA
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
+++ b/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
@@ -12,11 +12,8 @@
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
+++ b/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
@@ -13,7 +13,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/ESPNOW_Controller/fdrs_node_config.h
+++ b/examples/ESPNOW_Controller/fdrs_node_config.h
@@ -15,8 +15,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/ESPNOW_Controller/fdrs_node_config.h
+++ b/examples/ESPNOW_Controller/fdrs_node_config.h
@@ -13,7 +13,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/ESPNOW_Controller/fdrs_node_config.h
+++ b/examples/ESPNOW_Controller/fdrs_node_config.h
@@ -11,7 +11,12 @@
 //#define USE_LORA
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/ESPNOW_Controller/fdrs_node_config.h
+++ b/examples/ESPNOW_Controller/fdrs_node_config.h
@@ -12,11 +12,8 @@
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/ESPNOW_Sensor/fdrs_node_config.h
+++ b/examples/ESPNOW_Sensor/fdrs_node_config.h
@@ -15,8 +15,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/ESPNOW_Sensor/fdrs_node_config.h
+++ b/examples/ESPNOW_Sensor/fdrs_node_config.h
@@ -12,11 +12,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/ESPNOW_Sensor/fdrs_node_config.h
+++ b/examples/ESPNOW_Sensor/fdrs_node_config.h
@@ -13,7 +13,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/ESPNOW_Sensor/fdrs_node_config.h
+++ b/examples/ESPNOW_Sensor/fdrs_node_config.h
@@ -11,7 +11,12 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/ESPNOW_Stress_Test/fdrs_node_config.h
+++ b/examples/ESPNOW_Stress_Test/fdrs_node_config.h
@@ -11,8 +11,13 @@
 //#define USE_LORA
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
-//#define FDRS_DEBUG
-//
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+// #define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/ESPNOW_Stress_Test/fdrs_node_config.h
+++ b/examples/ESPNOW_Stress_Test/fdrs_node_config.h
@@ -12,11 +12,9 @@
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 // #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/ESPNOW_Stress_Test/fdrs_node_config.h
+++ b/examples/ESPNOW_Stress_Test/fdrs_node_config.h
@@ -13,7 +13,7 @@
 //#define POWER_CTRL    14
 
 // #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 
 // LoRa Configuration

--- a/examples/ESPNOW_Stress_Test/fdrs_node_config.h
+++ b/examples/ESPNOW_Stress_Test/fdrs_node_config.h
@@ -15,8 +15,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 // #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
@@ -43,7 +43,11 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
@@ -44,7 +44,7 @@
 #define LORA_SPI_MOSI 27
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
@@ -46,8 +46,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
@@ -43,11 +43,8 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
@@ -43,7 +43,11 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
@@ -44,7 +44,7 @@
 #define LORA_SPI_MOSI 27
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
@@ -46,8 +46,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
@@ -43,11 +43,8 @@
 #define LORA_SPI_MISO 19
 #define LORA_SPI_MOSI 27
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // OLED -- Displays console debugging messages on an SSD1306 I²C OLED
 ///#define USE_OLED    

--- a/examples/LoRa_Controller/fdrs_node_config.h
+++ b/examples/LoRa_Controller/fdrs_node_config.h
@@ -11,11 +11,8 @@
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/LoRa_Controller/fdrs_node_config.h
+++ b/examples/LoRa_Controller/fdrs_node_config.h
@@ -10,7 +10,12 @@
 #define USE_LORA
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/LoRa_Controller/fdrs_node_config.h
+++ b/examples/LoRa_Controller/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/LoRa_Controller/fdrs_node_config.h
+++ b/examples/LoRa_Controller/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/LoRa_Sensor/fdrs_node_config.h
+++ b/examples/LoRa_Sensor/fdrs_node_config.h
@@ -15,8 +15,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/LoRa_Sensor/fdrs_node_config.h
+++ b/examples/LoRa_Sensor/fdrs_node_config.h
@@ -12,11 +12,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/LoRa_Sensor/fdrs_node_config.h
+++ b/examples/LoRa_Sensor/fdrs_node_config.h
@@ -13,7 +13,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/LoRa_Sensor/fdrs_node_config.h
+++ b/examples/LoRa_Sensor/fdrs_node_config.h
@@ -11,7 +11,12 @@
 #define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
+++ b/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
@@ -14,11 +14,8 @@
 //#define DEEP_SLEEP
 //#define POWER_CTRL  14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276  // ESP32 SX1276 (TTGO)

--- a/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
+++ b/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
@@ -15,7 +15,7 @@
 //#define POWER_CTRL  14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276  // ESP32 SX1276 (TTGO)

--- a/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
+++ b/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
@@ -13,7 +13,12 @@
 
 //#define DEEP_SLEEP
 //#define POWER_CTRL  14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276  // ESP32 SX1276 (TTGO)

--- a/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
+++ b/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
@@ -17,8 +17,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276  // ESP32 SX1276 (TTGO)

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
+++ b/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
@@ -12,7 +12,7 @@
 #define POWER_CTRL    22
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
+++ b/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 #define POWER_CTRL    22
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
+++ b/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
+++ b/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 #define POWER_CTRL    22
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
@@ -10,7 +10,13 @@
 #define USE_LORA
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276  // ESP32 SX1276 (TTGO)
 #define LORA_SS    18

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276  // ESP32 SX1276 (TTGO)

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276  // ESP32 SX1276 (TTGO)

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
@@ -11,11 +11,8 @@
 //#define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276  // ESP32 SX1276 (TTGO)

--- a/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
+++ b/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
+++ b/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
+++ b/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
+++ b/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 #define POWER_CTRL    4
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
@@ -12,7 +12,7 @@
 #define POWER_CTRL    4
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 #define POWER_CTRL    4
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
@@ -12,7 +12,7 @@
 #define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 #define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 #define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
@@ -10,7 +10,12 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
@@ -12,7 +12,7 @@
 //#define POWER_CTRL    14
 
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
+//#define DBG_LEVEL 0    // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
@@ -14,8 +14,8 @@
 // Choose none or one of the debug options below.  
 // DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
@@ -11,11 +11,8 @@
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
 
-// Choose none or one of the debug options below.  
-// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
 #define FDRS_DEBUG     // Enable USB-Serial debugging
-// #define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
-// #define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+// #define DBG_LEVEL 0 // 0 for minimal messaging, 1 for troubleshooting, 2 for development
 
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276

--- a/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
@@ -10,7 +10,13 @@
 //#define USE_LORA
 #define DEEP_SLEEP
 //#define POWER_CTRL    14
-#define FDRS_DEBUG
+
+// Choose none or one of the debug options below.  
+// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
+#define FDRS_DEBUG     // Enable USB-Serial debugging
+// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
+// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
+
 // LoRa Configuration
 #define RADIOLIB_MODULE SX1276 //Tested on SX1276
 #define LORA_SS 18

--- a/extras/Gateway.md
+++ b/extras/Gateway.md
@@ -18,21 +18,21 @@ void loop() {
 ```
 
 ## Addresses
-#### ```#define UNIT_MAC 0xNN```
+#### `#define UNIT_MAC 0xNN`
 The ESP-NOW and LoRa address of the gateway. This is the address that nodes and other gateways will use to pass data to this device.
-#### ```#define ESPNOW_NEIGHBOR_1 0xNN```, ```ESPNOW_NEIGHBOR_2 0xNN```
+#### `#define ESPNOW_NEIGHBOR_1 0xNN`, `ESPNOW_NEIGHBOR_2 0xNN`
 The addresses of ESP-NOW repeaters neighboring this gateway.
-#### ```#define LORA_NEIGHBOR_1 0xNN```, ```LORA_NEIGHBOR_2 0xNN```
+#### `#define LORA_NEIGHBOR_1 0xNN`, `LORA_NEIGHBOR_2 0xNN`
 The addresses of LoRa repeaters neighboring this gateway.
 ## Interfaces
-#### ```#define USE_ESPNOW```
+#### `#define USE_ESPNOW`
 Enables ESP-NOW.
 
-#### ```#define USE_LORA```
+#### `#define USE_LORA`
 Enables LoRa. Ensure your pins are configured correctly.
-#### ```#define USE_WIFI```
+#### `#define USE_WIFI`
 Enables WiFi for use by MQTT. Do not enable WiFi and ESP-NOW simultaneously.
-#### ```#define USE_ETHERNET```
+#### `#define USE_ETHERNET`
 Enables ethernet to be used by MQTT. 
 
 ## Routing
@@ -45,35 +45,35 @@ Enables ethernet to be used by MQTT.
 #
 ### Events
 
-#### ```#define ESPNOWG_ACT ```
+#### `#define ESPNOWG_ACT `
 Actions that occur when data arrives from an ESP-NOW device that is *not* listed as a neighbor.
-#### ```#define LORAG_ACT ```
+#### `#define LORAG_ACT `
 Actions that occur when data arrives from a LoRa device that is *not* listed as a neighbor.
-#### ```#define SERIAL_ACT ```
+#### `#define SERIAL_ACT `
 Actions that occur when JSON data arrives over UART.
-#### ```#define MQTT_ACT ```
-Actions that occur when JSON data is posted to the MQTT topic defined by ```TOPIC_COMMAND``` in 'src/fdrs_globals.h'.
-#### ```#define INTERNAL_ACT ```
+#### `#define MQTT_ACT `
+Actions that occur when JSON data is posted to the MQTT topic defined by `TOPIC_COMMAND` in 'src/fdrs_globals.h'.
+#### `#define INTERNAL_ACT `
 Actions that occur when data is entered by a user-defined function. Used for sending the gateway's own voltage or temperature.
-#### ```#define ESPNOW1_ACT ``` and ```ESPNOW2_ACT ```
-Actions that occur when data arrives from the devices defined by ```ESPNOW_NEIGHBOR_1``` and ```ESPNOW_NEIGHBOR_2```.
-#### ```#define LORA1_ACT ``` and ```LORA2_ACT ```
-Actions that occur when data arrives from the devices defined by ```LORA_NEIGHBOR_1``` and ```LORA_NEIGHBOR_2```.
+#### `#define ESPNOW1_ACT ` and `ESPNOW2_ACT `
+Actions that occur when data arrives from the devices defined by `ESPNOW_NEIGHBOR_1` and `ESPNOW_NEIGHBOR_2`.
+#### `#define LORA1_ACT ` and `LORA2_ACT `
+Actions that occur when data arrives from the devices defined by `LORA_NEIGHBOR_1` and `LORA_NEIGHBOR_2`.
 #
 ### Actions
-#### ```sendSerial();```
+#### `sendSerial();`
 Transmits the data in JSON format via both the debugging terminal as well as a second UART interface. (If available. See below.)
-#### ```sendMQTT();```
-Posts the data in JSON format to the MQTT topic defined by ```TOPIC_DATA```
-#### ```sendESPNowNbr(1 or 2);```
-Sends the data to the address defined by ```ESPNOW_NEIGHBOR_1``` or ```ESPNOW_NEIGHBOR_2```
-#### ```sendESPNowPeers();```
+#### `sendMQTT();`
+Posts the data in JSON format to the MQTT topic defined by `TOPIC_DATA`
+#### `sendESPNowNbr(1 or 2);`
+Sends the data to the address defined by `ESPNOW_NEIGHBOR_1` or `ESPNOW_NEIGHBOR_2`
+#### `sendESPNowPeers();`
 Sends the data to any ESP-NOW controller node that has registered with this gateway as a peer.
-#### ```sendLoRaNbr(1 or 2);```
-Sends the data to the address defined by ```LORA_NEIGHBOR_1``` or ```LORA_NEIGHBOR_2```
-#### ```broadcastLoRa();```
+#### `sendLoRaNbr(1 or 2);`
+Sends the data to the address defined by `LORA_NEIGHBOR_1` or `LORA_NEIGHBOR_2`
+#### `broadcastLoRa();`
 Broadcasts the data to any LoRa controller node that is listening to this gateway. No registration is needed to pair with a LoRa controller.
-#### ```sendESPNow(0xNN);```
+#### `sendESPNow(0xNN);`
 Sends the data directly to the ESP-NOW gateway address provided. There is no LoRa equivalent of this function.
 
 ## Neighbors
@@ -83,24 +83,24 @@ Check out the configurations for the  [ESP-NOW](https://github.com/timmbogner/Fa
 
 #
 ## LoRa Configuration
-#### ```#define RADIOLIB_MODULE cccc```
+#### `#define RADIOLIB_MODULE cccc`
 The name of the RadioLib module being used. Tested modules: SX1276, SX1278, SX1262.
-#### ```#define LORA_SS n```
+#### `#define LORA_SS n`
 LoRa chip select pin.
-#### ```#define LORA_RST n```
+#### `#define LORA_RST n`
 LoRa reset pin.
-#### ```#define LORA_DIO n```
+#### `#define LORA_DIO n`
 LoRa DIO pin. This refers to DIO0 on SX127x chips and DIO1 on SX126x chips.
-#### ```#define LORA_BUSY n```
+#### `#define LORA_BUSY n`
 For SX126x chips: LoRa BUSY pin. For SX127x: DIO1 pin, or "RADIOLIB_NC" to leave it blank. 
-#### ```#define LORA_TXPWR n```
+#### `#define LORA_TXPWR n`
 LoRa TX power in dBm.
-#### ```#define USE_SX126X```
+#### `#define USE_SX126X`
 Enable this if using the SX126x series of LoRa chips.
 
-#### ```#define CUSTOM_SPI```
+#### `#define CUSTOM_SPI`
 Enable this to define non-default SPI pins.
-#### ```#define LORA_SPI_SCK n```, ```LORA_SPI_MISO n```, ```LORA_SPI_MOSI n```
+#### `#define LORA_SPI_SCK n`, `LORA_SPI_MISO n`, `LORA_SPI_MOSI n`
 Custom SPI pin definitions.
 
 #
@@ -108,61 +108,63 @@ Custom SPI pin definitions.
 
 The actual allowed values may vary by chip. Check the datasheet and/or RadioLib documentation.
 #
-#### ```#define LORA_FREQUENCY n```
+#### `#define LORA_FREQUENCY n`
 LoRa frequency in MHz. Allowed values range from 137.0 MHz to 1020.0 MHz.
-#### ```#define LORA_SF n```
+#### `#define LORA_SF n`
 LoRa spreading factor. Allowed values range from 6 to 12. 
-#### ```#define LORA_BANDWIDTH n```
+#### `#define LORA_BANDWIDTH n`
 LoRa bandwidth in kHz. Allowed values are 10.4, 15.6, 20.8, 31.25, 41.7, 62.5, 125, 250 and 500 kHz.
-#### ```#define LORA_CR n```
+#### `#define LORA_CR n`
 LoRa coding rate denominator. Allowed values range from 5 to 8.
-#### ```#define LORA_SYNCWORD n```
+#### `#define LORA_SYNCWORD n`
 LoRa sync word. Can be used to distinguish different networks. Note that 0x34 is reserved for LoRaWAN.
-#### ```#define LORA_INTERVAL n```
+#### `#define LORA_INTERVAL n`
 Interval between LoRa buffer releases. Must be longer than transmission time-on-air.
 
 ## WiFi and MQTT Configuration
 WiFi and MQTT parameters are generally configured in the 'src/fdrs_globals.h' file. Be sure to use the correct topic when sending MQTT commands. The following values may be set in the gateway configuration file if the user wishes to override the global value:
-#### ```#define WIFI_SSID "cccc"``` and ``` WIFI_PASS "cccc"  ```
+#### `#define WIFI_SSID "cccc"` and ` WIFI_PASS "cccc"  `
 WiFi credentials
-#### ```#define MQTT_ADDR "n.n.n.n"``` or ```MQTT_ADDR "cccc"```
+#### `#define MQTT_ADDR "n.n.n.n"` or `MQTT_ADDR "cccc"`
 The address of the MQTT server, either the IP address or domain name.
-#### ```#define MQTT_PORT n ```
+#### `#define MQTT_PORT n `
 The port of the MQTT server.
-#### ```#define MQTT_AUTH ```
+#### `#define MQTT_AUTH `
 Enable this if using MQTT authentication 
-#### ```#define MQTT_USER "cccc"``` and ```MQTT_PASS "cccc"```
+#### `#define MQTT_USER "cccc"` and `MQTT_PASS "cccc"`
 
 #
 ### SSD1306 OLED Display
 Built on the [ThingPulse OLED SSD1306 Library](https://github.com/ThingPulse/esp8266-oled-ssd1306)
-#### ```#define OLED_HEADER "cccc"```
+#### `#define OLED_HEADER "cccc"`
 The message to be displayed at the top of the screen.
-#### ```#define OLED_SDA n``` and ```OLED_SCL n```
+#### `#define OLED_SDA n` and `OLED_SCL n`
 OLED I²C pins.
-#### ```#define OLED_RST n```
+#### `#define OLED_RST n`
 OLED reset pin. Use '-1' if not present or known.
 #
 ### Miscellaneous
-#### ```#define FDRS_DEBUG```
+#### `#define FDRS_DEBUG`
 Enables debugging messages to be sent over the serial port and OLED display.
-#### ```#define RXD2 (pin)``` and ```TXD2 (pin)```
+#### `#define DBG_LEVEL n`
+Sets the level of verbosity in debug messages. '0' (default) shows only the most important system messages, '1' will show additional debug messages for troubleshooting, and '2' will show all messages, including those used in development. Much gratitude to  [Jeff Lehman](https://github.com/aviateur17) for this feature!
+#### `#define RXD2 (pin)` and `TXD2 (pin)`
 Configures a second, data-only UART interface on ESP32. The ESP8266 serial interface is not configurable, and thus these options don't apply.
 
-#### ```#define USE_LR```
+#### `#define USE_LR`
 Enables ESP-NOW Long-Range mode. Requires ESP32.
 
 ## User-Defined Functions
 This feature allows the user to send data from the gateway itself. For example: the battery level or ambient temperature at the gateway.
 
-Calling ```scheduleFDRS(function, interval);``` after initializing FDRS will schedule ```function()``` to be called every ```interval``` milliseconds.
+Calling `scheduleFDRS(function, interval);` after initializing FDRS will schedule `function()` to be called every `interval` milliseconds.
 
-Within this function, the user may utilize the same ```loadFDRS()``` and ```sendFDRS()``` commands used by sensors. After the data is sent, it triggers ```INTERNAL_ACT``` where it can be routed to the front-end.
+Within this function, the user may utilize the same `loadFDRS()` and `sendFDRS()` commands used by sensors. After the data is sent, it triggers `INTERNAL_ACT` where it can be routed to the front-end.
 
-#### ```loadFDRS(float data, uint8_t type, uint16_t id);```
+#### `loadFDRS(float data, uint8_t type, uint16_t id);`
 Loads some data into the current packet. 'data' is a float, 'type' is the data type, and 'id' is the DataReading id.
-#### ```sendFDRS();```
-Sends the current packet using actions defined by ```INTERNAL_ACT```. Does not return any value.
+#### `sendFDRS();`
+Sends the current packet using actions defined by `INTERNAL_ACT`. Does not return any value.
 
 **Example:**
 ``` cpp

--- a/extras/Node.md
+++ b/extras/Node.md
@@ -1,36 +1,6 @@
 # FDRS Node
-A node is a device that sends and receives data from a nearby gateway. A node can be a **sensor**, **controller**, ***or both***.
-## Addresses
-#### ```#define READING_ID  n```
-The unique ID that the node will use when sending sensor values. Can be any integer 0 - 65535. Nodes are not necessarily tied to this parameter. They can be subscribed to up to 256 different IDs or send using several different IDs.
-#### ```#define GTWY_MAC  0xnn```
-The ```UNIT_MAC``` of the gateway that this device will be paired with.
 
-## Usage
-#### ```beginFDRS();```
-Initializes FDRS, powers up the sensor array, and begins ESP-NOW and/or LoRa.
-#### ```uint32_t pingFDRS(timeout);```
-Sends a ping request to the device's paired gateway with a timeout in ms. Returns the ping time in ms as well as displaying it on the debugging console.
-
-## Sensor API
-#### ```loadFDRS(float data, uint8_t type, uint16_t id);```
-Loads some data into the current packet. 'data' is a float, 'type' is the data type (see below), and 'id' is the DataReading id.
-#### ```loadFDRS((float data, uint8_t type);```
-Same as above, but the 'id' is preset to the node's ```READING_ID```. 
-#### ```bool sendFDRS();```
-Sends the current packet using ESP-NOW and/or LoRa. Returns true if packet is confirmed to have been recieved successfully by the gateway.
-#### ```sleepFDRS(seconds)```
-Time to sleep in seconds. If ```DEEP_SLEEP``` is enabled, the device will enter sleep. Otherwise it will use a simple ```delay()```.
-
-## Controller API
-#### ```addFDRS(void callback);```
-Initializes controller functionality by selecting the function to be called when incoming commands are recieved. If using LoRa, the controller will automatically recieve any packets sent with broadcastLoRa(), provided they were sent by the paired gateway. ESP-NOW requires the device to register with its gateway before it will recieve incoming commands. This is done automatically, and the ESP-NOW node will continue recieving data until the paired gateway is reset. A maximum of 16 ESP-NOW controllers can recieve data from a single gateway. There is no limit to how many LoRa controllers can listen to the same gateway.
-#### ```subscribeFDRS(uint16_t sub_id);``` 
-Sets the device to listen for a specific DataReading id. When a DataReading with id ```sub_id``` is received, the callback function will be called and given the full DataReading as a parameter.
-#### ```unsubscribeFDRS(uint16_t sub_id);``` 
-Removes ```sub_id``` from subscription list.
-#### ```loopFDRS();``` 
-Always add this to ```loop()``` to handle the controller's listening capabilities.
+A node is a device that sends and receives data from a nearby gateway. This is where the user can communicate with a network of FDRS gateways using their own sketch. A node can be a **sensor** (sending data), **controller** (receiving data), ***or both***. 
 
 ## Basic Examples:
 ### Sensor
@@ -66,53 +36,87 @@ void fdrs_recv_cb(DataReading theData) {
 void setup() {
   beginFDRS();       // Start the system
   addFDRS(fdrs_recv_cb);  // Call fdrs_recv_cb() when data arrives.
-  subscribeFDRS(READING_ID);  // Subscribe to DataReadings with ID matching READING_ID
+  subscribeFDRS(42);  // Subscribe to DataReadings with ID 42
 }
 void loop() {
   loopFDRS();  // Listen for data
 }
 ```
 
+
+## Addresses
+#### `#define READING_ID  n`
+The unique ID that the node will use when sending sensor values. Can be any integer 0 - 65535. Nodes are not necessarily tied to this parameter. They can be subscribed to up to 256 different IDs or send using several different IDs.
+#### `#define GTWY_MAC  0xnn`
+The `UNIT_MAC` of the gateway that this device will be paired with.
+
+## Usage
+#### `beginFDRS();`
+Initializes FDRS, powers up the sensor array, and begins ESP-NOW and/or LoRa.
+#### `uint32_t pingFDRS(timeout);`
+Sends a ping request to the device's paired gateway with a timeout in ms. Returns the ping time in ms and displays it on the debugging console.
+
+## Sensor API
+#### `loadFDRS(float data, uint8_t type, uint16_t id);`
+Loads some data into the current packet. 'data' is a float, 'type' is the data type (see below), and 'id' is the DataReading id.
+#### `loadFDRS((float data, uint8_t type);`
+Same as above, but the 'id' is preset to the node's `READING_ID`. 
+#### `bool sendFDRS();`
+Sends the current packet using ESP-NOW and/or LoRa. Returns true if packet is confirmed to have been recieved successfully by the gateway.
+#### `sleepFDRS(seconds)`
+Time to sleep in seconds. If ```DEEP_SLEEP``` is enabled, the device will enter sleep. Otherwise it will use a simple ```delay()```.
+
+## Controller API
+#### ```addFDRS(void callback);```
+Initializes controller functionality by selecting the function to be called when incoming commands are recieved. If using LoRa, the controller will automatically recieve any packets sent with broadcastLoRa(), provided they were sent by the paired gateway. ESP-NOW requires the device to register with its gateway before it will recieve incoming commands. This is done automatically, and the ESP-NOW node will continue recieving data until the paired gateway is reset. A maximum of 16 ESP-NOW controllers can recieve data from a single gateway. There is no limit to how many LoRa controllers can listen to the same gateway.
+#### ```subscribeFDRS(uint16_t sub_id);``` 
+Sets the device to listen for a specific DataReading id. When a DataReading with id ```sub_id``` is received, the callback function will be called and given the full DataReading as a parameter.
+#### ```unsubscribeFDRS(uint16_t sub_id);``` 
+Removes ```sub_id``` from subscription list.
+#### ```loopFDRS();``` 
+Always add this to ```loop()``` to handle the controller's listening capabilities.
+
 ## Configuration
 
-#### ```#define USE_ESPNOW```
+#### `#define USE_ESPNOW`
 Enables/disables ESP-NOW.
-#### ```#define USE_LORA```
+#### `#define USE_LORA`
 Enables/disables LoRa.
-#### ```#define LORA_ACK```
-Enables LoRa packet acknowledgement. The device will use CRC to ensure that the data arrived at its destination correctly. If disabled, ```sendFDRS()``` will always return true when sending LoRa packets.
-
-Thanks to [aviateur17](https://github.com/aviateur17) for this feature!
-#### ```#define FDRS_DEBUG```
+#### `#define FDRS_DEBUG`
 This definition enables debug messages to be sent over the serial port. If disabled, no serial debug interface will be initialized. 
-#### ```#define DEEP_SLEEP```
+#### `#define DBG_LEVEL n`
+Sets the level of verbosity in debug messages. '0' (default) shows only the most important system messages, '1' will show additional debug messages for troubleshooting, and '2' will show all messages, including those used in development. Much gratitude to  [Jeff Lehman](https://github.com/aviateur17) for this feature!
+#### `#define DEEP_SLEEP`
 If enabled, device will enter deep-sleep when the sleepFDRS() command is used. If using ESP8266, be sure that you connect the WAKE pin (GPIO 16) to RST or your device will not wake up. 
-#### ```#define POWER_CTRL n```
+#### `#define POWER_CTRL n`
 If defined, power control will bring a GPIO pin high when FDRS is initialized. This is useful for powering sensors while running on battery.
 #
 ## LoRa Configuration
-#### ```#define RADIOLIB_MODULE cccc```
+#### ```#define LORA_ACK```
+Enables LoRa packet acknowledgement. The device will use CRC to ensure that the data arrived at its destination correctly. If disabled, ```sendFDRS()``` will always return true when sending LoRa packets.
+Thanks [Jeff Lehman](https://github.com/aviateur17) for this feature!
+#### `#define RADIOLIB_MODULE cccc`
 The name of the RadioLib module being used. Tested modules: SX1276, SX1278, SX1262.
-#### ```#define LORA_SS n```
+#### `#define LORA_SS n`
 LoRa chip select pin.
-#### ```#define LORA_RST n```
+#### `#define LORA_RST n`
 LoRa reset pin.
-#### ```#define LORA_DIO n```
+#### `#define LORA_DIO n`
 LoRa DIO pin. This refers to DIO1 on SX127x chips and DIO1 on SX126x chips.
-#### ```#define LORA_BUSY n```
+#### `#define LORA_BUSY n`
 For SX126x chips: LoRa BUSY pin. For SX127x: DIO1 pin, or "RADIOLIB_NC" to leave it blank. 
-#### ```#define LORA_TXPWR n```
+#### `#define LORA_TXPWR n`
 LoRa TX power in dBm.
-#### ```#define USE_SX126X```
+#### `#define USE_SX126X`
 Enable this if using the SX126x series of LoRa chips.
 #
 ### SSD1306 OLED Display
 Built on the [ThingPulse OLED SSD1306 Library](https://github.com/ThingPulse/esp8266-oled-ssd1306)
-##### ```#define OLED_HEADER "cccc"```
+##### `#define OLED_HEADER "cccc"`
 The message to be displayed at the top of the screen.
-#### ```#define OLED_SDA n``` and ```OLED_SCL n```
+#### `#define OLED_SDA n` and `OLED_SCL n`
 OLED I²C pins.
-#### ```#define OLED_RST n```
+#### `#define OLED_RST n`
 OLED reset pin. Use '-1' if not present or known.
 #
 ## Callback Function

--- a/src/fdrs_debug.h
+++ b/src/fdrs_debug.h
@@ -1,42 +1,27 @@
-
-#if !defined(FDRS_DEBUG) && !defined(FDRS_DEBUG_1) && !defined(FDRS_DEBUG_2)
-#ifdef USE_OLED
-#define DBG(a) debug_OLED(String(a));
-#define DBG1(a)
-#define DBG2(a)
-#else
-#define DBG(a)
-#define DBG1(a)
-#define DBG2(a)
-#endif
+#ifndef DBG_LEVEL
+    #define DBG_LEVEL GLOBAL_DBG_LEVEL
 #endif
 
 #ifdef FDRS_DEBUG
-#ifdef USE_OLED
-#define DBG(a) Serial.println(a); debug_OLED(String(a));
+    #ifdef USE_OLED
+        #define DBG(a) ("    "); Serial.println(a); debug_OLED(String(a));
+    #else
+        #define DBG(a) Serial.print("    "); Serial.println(a);
+    #endif // USE_OLED
+    #if (DBG_LEVEL == 1)
+        #define DBG1(a) Serial.print("[1] "); Serial.println(a);
+        #define DBG2(a)
+    #endif
+    #if (DBG_LEVEL >= 2)
+        #define DBG1(a) Serial.print("[1] "); Serial.println(a);
+        #define DBG2(a) Serial.print("[2] "); Serial.println(a);
+    #endif
 #else
-#define DBG(a) Serial.println(a);
-#endif // USE_OLED
-#define DBG1(a)
-#define DBG2(a)
+    #ifdef USE_OLED
+        #define DBG(a) debug_OLED(String(a));
+    #else
+        #define DBG(a)
+    #endif // USE_OLED
+    #define DBG1(a)
+    #define DBG2(a)
 #endif // FDRS_DEBUG
-
-#ifdef FDRS_DEBUG_1
-#ifdef USE_OLED
-#define DBG(a) Serial.print("    "); Serial.println(a); debug_OLED(String(a));
-#else
-#define DBG(a) Serial.print("    "); Serial.println(a);
-#endif // USE_OLED
-#define DBG1(a) Serial.print("[1] "); Serial.println(a);
-#define DBG2(a)
-#endif //FDRS_DEBUG_1
-
-#ifdef FDRS_DEBUG_2
-#ifdef USE_OLED
-#define DBG(a) Serial.print("    "); Serial.println(a); debug_OLED(String(a));
-#else
-#define DBG(a) Serial.print("    "); Serial.println(a);
-#endif // USE_OLED
-#define DBG2(a) Serial.print("[2] "); Serial.println(a);
-#define DBG1(a) Serial.print("[1] "); Serial.println(a);
-#endif //FDRS_DEBUG_2

--- a/src/fdrs_debug.h
+++ b/src/fdrs_debug.h
@@ -8,6 +8,10 @@
     #else
         #define DBG(a) Serial.print("    "); Serial.println(a);
     #endif // USE_OLED
+    #if (DBG_LEVEL == 0)
+        #define DBG1(a);
+        #define DBG2(a);
+    #endif
     #if (DBG_LEVEL == 1)
         #define DBG1(a) Serial.print("[1] "); Serial.println(a);
         #define DBG2(a)

--- a/src/fdrs_debug.h
+++ b/src/fdrs_debug.h
@@ -1,14 +1,42 @@
-#ifdef FDRS_DEBUG
-#ifdef USE_OLED
-#define DBG(a) debug_OLED(String(a)); \
-Serial.println(a);
-#else
-#define DBG(a) Serial.println(a);
-#endif
-#else
+
+#if !defined(FDRS_DEBUG) && !defined(FDRS_DEBUG_1) && !defined(FDRS_DEBUG_2)
 #ifdef USE_OLED
 #define DBG(a) debug_OLED(String(a));
+#define DBG1(a)
+#define DBG2(a)
 #else
 #define DBG(a)
+#define DBG1(a)
+#define DBG2(a)
 #endif
 #endif
+
+#ifdef FDRS_DEBUG
+#ifdef USE_OLED
+#define DBG(a) Serial.println(a); debug_OLED(String(a));
+#else
+#define DBG(a) Serial.println(a);
+#endif // USE_OLED
+#define DBG1(a)
+#define DBG2(a)
+#endif // FDRS_DEBUG
+
+#ifdef FDRS_DEBUG_1
+#ifdef USE_OLED
+#define DBG(a) Serial.print("    "); Serial.println(a); debug_OLED(String(a));
+#else
+#define DBG(a) Serial.print("    "); Serial.println(a);
+#endif // USE_OLED
+#define DBG1(a) Serial.print("[1] "); Serial.println(a);
+#define DBG2(a)
+#endif //FDRS_DEBUG_1
+
+#ifdef FDRS_DEBUG_2
+#ifdef USE_OLED
+#define DBG(a) Serial.print("    "); Serial.println(a); debug_OLED(String(a));
+#else
+#define DBG(a) Serial.print("    "); Serial.println(a);
+#endif // USE_OLED
+#define DBG2(a) Serial.print("[2] "); Serial.println(a);
+#define DBG1(a) Serial.print("[1] "); Serial.println(a);
+#endif //FDRS_DEBUG_2

--- a/src/fdrs_gateway.h
+++ b/src/fdrs_gateway.h
@@ -118,12 +118,25 @@ void beginFDRS()
   Serial.begin(115200);
   UART_IF.begin(115200, SERIAL_8N1, RXD2, TXD2);
 #endif
+
 #ifdef USE_OLED
   init_oled();
   DBG("Display initialized!");
   DBG("Hello, World!");
 #endif
-  DBG("Address:" + String(UNIT_MAC, HEX));
+  DBG("");
+  DBG("Initializing FDRS Gateway!");
+  DBG("Address: " + String(UNIT_MAC, HEX));
+#ifdef USE_ESPNOW
+  DBG1("ESPNOW_NEIGHBOR_1: " + String(ESPNOW_NEIGHBOR_1, HEX));
+  DBG1("ESPNOW_NEIGHBOR_2: " + String(ESPNOW_NEIGHBOR_2, HEX));
+#endif // USE_ESPNOW
+#ifdef USE_LORA
+  DBG1("LORA_NEIGHBOR_1: " + String(LORA_NEIGHBOR_1, HEX));
+  DBG1("LORA_NEIGHBOR_2: " + String(LORA_NEIGHBOR_2, HEX));
+#endif // USE_LORA
+  DBG("Debugging verbosity level: " + String(DBG_LEVEL));
+
 #ifdef USE_LORA
   begin_lora();
   scheduleFDRS(asyncReleaseLoRaFirst, FDRS_LORA_INTERVAL);

--- a/src/fdrs_gateway_espnow.h
+++ b/src/fdrs_gateway_espnow.h
@@ -119,7 +119,7 @@ int find_espnow_peer()
   {
     if (peer_list[i].last_seen == 0)
     {
-      // DBG("Using peer entry " + String(i));
+      DBG1("Using peer entry " + String(i));
       return i;
     }
   }
@@ -127,7 +127,7 @@ int find_espnow_peer()
   {
     if ((millis() - peer_list[i].last_seen) >= PEER_TIMEOUT)
     {
-      // DBG("Recycling peer entry " + String(i));
+      DBG1("Recycling peer entry " + String(i));
       esp_now_del_peer(peer_list[i].mac);
 
       return i;
@@ -140,18 +140,18 @@ int find_espnow_peer()
 // Returns the index of the peer list array element that contains the provided MAC address, -1 if not found
 int getFDRSPeer(uint8_t *mac)
 {
-  // DBG("Getting peer #");
+  DBG1("Getting peer #");
 
   for (int i = 0; i < 16; i++)
   {
     if (memcmp(mac, &peer_list[i].mac, 6) == 0)
     {
-      DBG("Peer is entry #" + String(i));
+      DBG1("Peer is entry #" + String(i));
       return i;
     }
   }
 
-  // DBG("Couldn't find peer");
+  DBG1("Couldn't find peer");
   return -1;
 }
 
@@ -162,7 +162,7 @@ void add_espnow_peer()
   if (peer_num == -1) // if the device isn't registered
   {
     int open_peer = find_espnow_peer();            // find open spot in peer_list
-    DBG("New device will be registered as " + String(open_peer));
+    DBG1("New device will be registered as " + String(open_peer));
     memcpy(&peer_list[open_peer].mac, &incMAC, 6); // save MAC to open spot
     peer_list[open_peer].last_seen = millis();
 #if defined(ESP32)
@@ -186,7 +186,7 @@ void add_espnow_peer()
   }
   else
   {
-    DBG("Refreshing existing peer registration");
+    DBG1("Refreshing existing peer registration");
     peer_list[peer_num].last_seen = millis();
 
     SystemPacket sys_packet = {.cmd = cmd_add, .param = PEER_TIMEOUT};

--- a/src/fdrs_gateway_espnow.h
+++ b/src/fdrs_gateway_espnow.h
@@ -44,7 +44,7 @@ void OnDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len)
   memcpy(&incMAC, mac, sizeof(incMAC));
   if (len < sizeof(DataReading))
   {
-    DBG("ESP-NOW System Packet");
+    DBG1("ESP-NOW System Packet");
     memcpy(&theCmd, incomingData, sizeof(theCmd));
     memcpy(&incMAC, mac, sizeof(incMAC));
     return;
@@ -140,7 +140,7 @@ int find_espnow_peer()
 // Returns the index of the peer list array element that contains the provided MAC address, -1 if not found
 int getFDRSPeer(uint8_t *mac)
 {
-  DBG1("Getting peer #");
+  DBG2("Getting peer #");
 
   for (int i = 0; i < 16; i++)
   {
@@ -157,12 +157,12 @@ int getFDRSPeer(uint8_t *mac)
 
 void add_espnow_peer()
 {
-  DBG("Device requesting peer registration");
+  DBG1("Device requesting peer registration");
   int peer_num = getFDRSPeer(&incMAC[0]);
   if (peer_num == -1) // if the device isn't registered
   {
     int open_peer = find_espnow_peer();            // find open spot in peer_list
-    DBG1("New device will be registered as " + String(open_peer));
+    DBG("Registering new peer. Slot: " + String(open_peer));
     memcpy(&peer_list[open_peer].mac, &incMAC, 6); // save MAC to open spot
     peer_list[open_peer].last_seen = millis();
 #if defined(ESP32)

--- a/src/fdrs_gateway_mqtt.h
+++ b/src/fdrs_gateway_mqtt.h
@@ -120,7 +120,7 @@ void mqtt_callback(char *topic, byte *message, unsigned int length)
     if (error)
     { // Test if parsing succeeds.
         DBG("json parse err");
-        DBG(incomingString);
+        DBG1(incomingString);
         return;
     }
     else

--- a/src/fdrs_gateway_serial.h
+++ b/src/fdrs_gateway_serial.h
@@ -35,8 +35,8 @@ void getSerial() {
   JsonDocument doc;
   DeserializationError error = deserializeJson(doc, incomingString);
   if (error) {    // Test if parsing succeeds.
-    //    DBG("json parse err");
-    //    DBG(incomingString);
+        DBG("json parse err");
+        DBG1(incomingString);
     return;
   } else {
     int s = doc.size();

--- a/src/fdrs_globals.h
+++ b/src/fdrs_globals.h
@@ -6,6 +6,8 @@
 #ifndef __FDRS_GLOBALS_h__
 #define __FDRS_GLOBALS_h__
 
+#define GLOBAL_DBG_LEVEL 0
+
 #define GLOBAL_WIFI_SSID "Your SSID"
 #define GLOBAL_WIFI_PASS "Password"
 #define GLOBAL_DNS1_IPADDRESS    "8.8.8.8"   // Default to Google Primary DNS

--- a/src/fdrs_node.h
+++ b/src/fdrs_node.h
@@ -82,10 +82,22 @@ void beginFDRS()
   DBG("Display initialized!");
   DBG("Hello, World!");
 #endif
-  DBG("FDRS User Node initializing...");
-  DBG(" Reading ID " + String(READING_ID));
-  DBG(" Gateway: " + String(GTWY_MAC, HEX));
+  DBG("");
+  DBG("Initializing FDRS Node!");
+  DBG("Reading ID " + String(READING_ID));
+  DBG("Gateway: " + String(GTWY_MAC, HEX));
+  DBG("Debugging verbosity level: " + String(DBG_LEVEL));
+#ifdef USE_ESPNOW
+  DBG1("ESP-NOW is enabled.");
+#endif
+#ifdef USE_LORA
+  DBG1("LoRa is enabled.");
+#endif
+#ifdef DEEP_SLEEP
+  DBG1("Deep sleep is enabled.");
+#endif
 #ifdef POWER_CTRL
+  DBG1("Power control is enabled on pin " + String(POWER_CTRL));
   DBG("Powering up the sensor array!");
   pinMode(POWER_CTRL, OUTPUT);
   digitalWrite(POWER_CTRL, 1);
@@ -131,13 +143,13 @@ void beginFDRS()
   memcpy(peerInfo.peer_addr, broadcast_mac, 6);
   if (esp_now_add_peer(&peerInfo) != ESP_OK)
   {
-    DBG("Failed to add peer bcast");
+    DBG(" Failed to add peer bcast");
     return;
   }
   memcpy(peerInfo.peer_addr, gatewayAddress, 6);
   if (esp_now_add_peer(&peerInfo) != ESP_OK)
   {
-    DBG("Failed to add peer");
+    DBG(" Failed to add peer");
     return;
   }
 #endif

--- a/src/fdrs_node_espnow.h
+++ b/src/fdrs_node_espnow.h
@@ -95,7 +95,7 @@ bool refresh_registration()
 #ifdef USE_ESPNOW
   SystemPacket sys_packet = {.cmd = cmd_add, .param = 0};
   esp_now_send(gatewayAddress, (uint8_t *)&sys_packet, sizeof(SystemPacket));
-  DBG("Refreshing registration to " + String(gatewayAddress[5]));
+  DBG1("Refreshing registration to " + String(gatewayAddress[5]));
   uint32_t add_start = millis();
   is_added = false;
   while ((millis() - add_start) <= 1000) // 1000ms timeout
@@ -103,12 +103,12 @@ bool refresh_registration()
     yield();
     if (is_added)
     {
-      DBG("Registration accepted. Timeout: " + String(gtwy_timeout));
+      DBG1("Registration accepted. Timeout: " + String(gtwy_timeout));
       last_refresh = millis();
       return true;
     }
   }
-  DBG("No gateways accepted the request");
+  DBG1("No gateways accepted the request");
   return false;
 #endif // USE_ESPNOW
   return true;


### PR DESCRIPTION
Per discussion #192 , add two additional levels of logging verbosity FDRS_DEBUG_1 and FDRS_DEBUG_2.

FDRS_DEBUG will only show basic output so that end users are not overloaded with information and to help speed up processing of code.   Additional debug levels can be used to troubleshoot and for development.

```
// Choose none or one of the debug options below.
// DEBUG will show some information but for troubleshooting a good level would be FDRS_DEBUG_1
#define FDRS_DEBUG     // Enable USB-Serial debugging
// define FDRS_DEBUG_1 // Additional logging messages for troubleshooting purposes - commment out the other FDRS_DEBUG options
// define FDRS_DEBUG_2 // Show all logging messages for development purposes - comment out the other FDRS_DEBUG options
```