### PR TITLE
Optionally Synchronous sendFDRS()

### DIFF
--- a/src/fdrs_node.h
+++ b/src/fdrs_node.h
@@ -220,6 +220,7 @@ bool sendFDRSinternal()
 bool sendFDRS(bool is_async)
 {
   bool ret = sendFDRSinternal();
+#ifdef USE_LORA
   if (!is_async)
   {
     unsigned long timeout = millis() + 1000;
@@ -229,6 +230,7 @@ bool sendFDRS(bool is_async)
       yield();
     }
   }
+#endif //USE_LORA
   return ret;
 }
 

--- a/src/fdrs_node.h
+++ b/src/fdrs_node.h
@@ -170,7 +170,7 @@ void handleIncoming()
   }
 }
 
-bool sendFDRS()
+bool sendFDRSinternal()
 {
   if(data_count == 0) {
     return false;
@@ -216,6 +216,27 @@ bool sendFDRS()
   }
 #endif
 }
+
+bool sendFDRS(bool is_async)
+{
+  bool ret = sendFDRSinternal();
+  if (!is_async)
+  {
+    unsigned long timeout = millis() + 1000;
+    while (millis() < timeout && (!ISBUFFEMPTY(drBuff) || !ISBUFFEMPTY(spBuff)))
+    {
+      handleLoRa();
+      yield();
+    }
+  }
+  return ret;
+}
+
+bool sendFDRS()
+{
+  return sendFDRS(false);
+}
+
 
 void loadFDRS(float d, uint8_t t)
 {


### PR DESCRIPTION
With this change, the system sends all buffered LoRa transmissions before leaving sendFDRS(). This emulates a synchronous send routine, despite our background operations now occuring asynchronously. If a user is sending and receiving data at the same time, they can use the asynchronous sendFDRS(true), which only sends the data to the buffer.

This still needs:

- the examples currently using sendFDRS() asyncronously to be changed,
- documentation adjusted
- testing that ESP-NOW isn't affected
- optimize deep-sleep. It needs to clear out or "flush" the send buffer before sleeping. (Thanks for reminding me of that word @fairoldi :D)