### PR TITLE
Add Timekeeping global defines

### DIFF
--- a/examples/0_MQTT_Gateway/fdrs_gateway_config.h
+++ b/examples/0_MQTT_Gateway/fdrs_gateway_config.h
@@ -86,12 +86,11 @@
 //#define MQTT_USER   "Your MQTT Username"
 //#define MQTT_PASS   "Your MQTT Password"
 
-// NTP Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for gateways
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define TIME_SERVER       "0.us.pool.ntp.org"       // NTP time server to use. If FQDN at least one DNS server is required to resolve name
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_FETCHNTP     60      // Time, in minutes, between fetching time from NTP server
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug
-#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices
+#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices.  0 will only send when time is updated

--- a/examples/1_UART_Gateway/fdrs_gateway_config.h
+++ b/examples/1_UART_Gateway/fdrs_gateway_config.h
@@ -86,12 +86,11 @@
 //#define MQTT_USER   "Your MQTT Username"
 //#define MQTT_PASS   "Your MQTT Password"
 
-// NTP Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for gateways
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define TIME_SERVER       "0.us.pool.ntp.org"       // NTP time server to use. If FQDN at least one DNS server is required to resolve name
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_FETCHNTP     60      // Time, in minutes, between fetching time from NTP server
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug
-#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices
+#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices.  0 will only send when time is updated

--- a/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
+++ b/examples/2_ESPNOW_Repeater/fdrs_gateway_config.h
@@ -86,12 +86,11 @@
 //#define MQTT_USER   "Your MQTT Username"
 //#define MQTT_PASS   "Your MQTT Password"
 
-// NTP Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for gateways
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define TIME_SERVER       "0.us.pool.ntp.org"       // NTP time server to use. If FQDN at least one DNS server is required to resolve name
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_FETCHNTP     60      // Time, in minutes, between fetching time from NTP server
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug
-#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices
+#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices.  0 will only send when time is updated

--- a/examples/3_LoRa_Repeater/fdrs_gateway_config.h
+++ b/examples/3_LoRa_Repeater/fdrs_gateway_config.h
@@ -86,12 +86,11 @@
 //#define MQTT_USER   "Your MQTT Username"
 //#define MQTT_PASS   "Your MQTT Password"
 
-// NTP Time settings
-#define USDST
-// #define EUDST
+/// NTP Time settings for gateways
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define TIME_SERVER       "0.us.pool.ntp.org"       // NTP time server to use. If FQDN at least one DNS server is required to resolve name
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_FETCHNTP     60      // Time, in minutes, between fetching time from NTP server
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug
-#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices
+#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices.  0 will only send when time is updated

--- a/examples/Controller_examples/ControllerTime/fdrs_node_config.h
+++ b/examples/Controller_examples/ControllerTime/fdrs_node_config.h
@@ -27,9 +27,8 @@
 
 //#define USE_LR  // Use ESP-NOW LR mode (ESP32 only)
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
-#define TIME_PRINTTIME    99      // Time, in minutes, between printing local time to debug
+#define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Controller_examples/FastLED/fdrs_node_config.h
+++ b/examples/Controller_examples/FastLED/fdrs_node_config.h
@@ -41,9 +41,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Controller_examples/Irrigation/fdrs_node_config.h
+++ b/examples/Controller_examples/Irrigation/fdrs_node_config.h
@@ -41,9 +41,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Controller_examples/LilyGo_TWatch2020/fdrs_node_config.h
+++ b/examples/Controller_examples/LilyGo_TWatch2020/fdrs_node_config.h
@@ -26,9 +26,8 @@
 
 //#define USE_LR  // Use ESP-NOW LR mode (ESP32 only)
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
-#define TIME_PRINTTIME    10      // Time, in minutes, between printing local time to debug
+#define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
+++ b/examples/Controller_examples/TFT_eSPI_fdrs/fdrs_node_config.h
@@ -41,9 +41,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/ESPNOW_Controller/fdrs_node_config.h
+++ b/examples/ESPNOW_Controller/fdrs_node_config.h
@@ -41,9 +41,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/ESPNOW_Sensor/fdrs_node_config.h
+++ b/examples/ESPNOW_Sensor/fdrs_node_config.h
@@ -41,9 +41,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/ESPNOW_Stress_Test/fdrs_node_config.h
+++ b/examples/ESPNOW_Stress_Test/fdrs_node_config.h
@@ -41,9 +41,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/1_MQTT_Gateway_Ethernet/fdrs_gateway_config.h
@@ -87,12 +87,11 @@
 //#define MQTT_USER   "Your MQTT Username"
 //#define MQTT_PASS   "Your MQTT Password"
 
-// NTP Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for gateways
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define TIME_SERVER       "0.us.pool.ntp.org"       // NTP time server to use. If FQDN at least one DNS server is required to resolve name
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_FETCHNTP     60      // Time, in minutes, between fetching time from NTP server
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug
-#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices
+#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices.  0 will only send when time is updated

--- a/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
+++ b/examples/Gateway_Examples/Repeater_Voltage/fdrs_gateway_config.h
@@ -78,12 +78,11 @@
 //#define MQTT_USER   "Your MQTT Username"
 //#define MQTT_PASS   "Your MQTT Password"
 
-// NTP Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for gateways
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define TIME_SERVER       "0.us.pool.ntp.org"       // NTP time server to use. If FQDN at least one DNS server is required to resolve name
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_FETCHNTP     60      // Time, in minutes, between fetching time from NTP server
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug
-#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices
+#define TIME_SEND_INTERVAL 10    // Time, in minutes, between sending out time to remote devices.  0 will only send when time is updated

--- a/examples/LoRa_Controller/fdrs_node_config.h
+++ b/examples/LoRa_Controller/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/LoRa_Sensor/fdrs_node_config.h
+++ b/examples/LoRa_Sensor/fdrs_node_config.h
@@ -41,9 +41,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/LoRa_Stress_Test/fdrs_node_config.h
+++ b/examples/LoRa_Stress_Test/fdrs_node_config.h
@@ -39,9 +39,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/AHT20_fdrs/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BME280_fdrs/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/BMP280_fdrs/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
+++ b/examples/Sensor_Examples/CapacitiveSoil/fdrs_node_config.h
@@ -43,9 +43,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DHT22_fdrs/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/DS18B20_fdrs/fdrs_node_config.h
@@ -39,9 +39,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
+++ b/examples/Sensor_Examples/FrequencyCounter/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/GenericGPS_fdrs/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
+++ b/examples/Sensor_Examples/KisssysGypsum/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
+++ b/examples/Sensor_Examples/LilyGo_HiGrow_32/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MESB_fdrs/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/MLX90614_fdrs/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
+++ b/examples/Sensor_Examples/SHT20_fdrs/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TSL2561/fdrs_node_config.h
@@ -41,9 +41,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
+++ b/examples/Sensor_Examples/TippingBucket/fdrs_node_config.h
@@ -40,9 +40,8 @@
 #define LORA_TXPWR 17    // LoRa TX power in dBm (: +2dBm - +17dBm (for SX1276-7) +20dBm (for SX1278))
 #define LORA_ACK        // Request LoRa acknowledgment.
 
-// Time settings
-#define USDST
-// #define EUDST
+// NTP Time settings for controllers and sensors
+#define DST_RULE        USDST     // Use US DST Rules - Change to EUDST to use European Union DST Rules
 #define STD_OFFSET      (-6)                // Local standard time offset in hours from UTC - if unsure, check https://time.is
 #define DST_OFFSET      (STD_OFFSET + 1)    // Local savings time offset in hours from UTC - if unsure, check https://time.is
 #define TIME_PRINTTIME    15     // Time, in minutes, between printing local time to debug

--- a/src/fdrs_globals.h
+++ b/src/fdrs_globals.h
@@ -28,6 +28,7 @@
 #define TOPIC_DATA_BACKLOG "fdrs/databacklog"   // Used in filesystem module
 
 // NTP Time Server
+#define GLOBAL_DST_RULE        USDST       // Use US DST Rules - Change to EUDST for European rules
 #define GLOBAL_TIME_SERVER      "0.us.pool.ntp.org"
 #define GLOBAL_LOCAL_OFFSET     (-5)    // Time in hours between local time and UTC
 #define GLOBAL_TIME_FETCHNTP    60      // Time in minutes between fetching time from NTP server

--- a/src/fdrs_time.h
+++ b/src/fdrs_time.h
@@ -1,6 +1,6 @@
 #include <sys/time.h>
 
-#define MIN_TS 1714000000 // Time in Unit timestamp format should be greater than this number to be valid
+#define MIN_TS 1718000000 // Time in Unit timestamp format should be greater than this number to be valid
 #define MAX_TS 3318000000 // time in Unit timestamp format should be less than this number to be valid
 #define VALID_TS(_unixts) ( (_unixts > MIN_TS && _unixts < MAX_TS) ? true : false )
 
@@ -8,20 +8,15 @@
 #define TDIFFRAND(prevMs,durationMs) (millis() - prevMs > (durationMs + random(0,10000)))
 #define TDIFFSEC(prevMs,durationSec) (millis() - prevMs > (durationSec * 1000))
 #define TDIFFMIN(prevMs,durationMin) (millis() - prevMs > (durationMin * 60 * 1000))
+#define USDST 0
+#define EUDST 1
 
-// select Time, in minutes, between sending out time
-#if defined(TIME_SEND_INTERVAL)
-#define FDRS_TIME_SEND_INTERVAL TIME_SEND_INTERVAL
+// US/EU Daylight Savings Time Rules
+#if defined(DST_RULE)
+#define FDRS_DST_RULE DST_RULE
 #else
-#define FDRS_TIME_SEND_INTERVAL GLOBAL_TIME_SEND_INTERVAL
-#endif // TIME_SEND_INTERVAL
-
-// select Time, in minutes, between time printed configuration
-#if defined(TIME_PRINTTIME)
-#define FDRS_TIME_PRINTTIME TIME_PRINTTIME
-#else
-#define FDRS_TIME_PRINTTIME GLOBAL_TIME_PRINTTIME
-#endif // TIME_PRINTTIME
+#define FDRS_DST_RULE GLOBAL_DST_RULE
+#endif // DST_RULE
 
 // select Local Standard time Offset from UTC configuration
 #if defined(STD_OFFSET)
@@ -36,6 +31,20 @@
 #else
 #define FDRS_DST_OFFSET GLOBAL_DST_OFFSET
 #endif // DST_OFFSET
+
+// select Time, in minutes, between time printed configuration
+#if defined(TIME_PRINTTIME)
+#define FDRS_TIME_PRINTTIME TIME_PRINTTIME
+#else
+#define FDRS_TIME_PRINTTIME GLOBAL_TIME_PRINTTIME
+#endif // TIME_PRINTTIME
+
+// select Time, in minutes, between sending out time
+#if defined(TIME_SEND_INTERVAL)
+#define FDRS_TIME_SEND_INTERVAL TIME_SEND_INTERVAL
+#else
+#define FDRS_TIME_SEND_INTERVAL GLOBAL_TIME_SEND_INTERVAL
+#endif // TIME_SEND_INTERVAL
 
 // US DST Start - 2nd Sunday in March - 02:00 local time
 // US DST End - 1st Sunday in November - 02:00 local time
@@ -170,7 +179,7 @@ void checkDST() {
       struct tm dstBegin;
       dstBegin.tm_year = timeinfo.tm_year;
       dstBegin.tm_mon = 2;
-#ifdef USDST
+#if (FDRS_DST_RULE == USDST)
       dstBegin.tm_mday = 8;
       dstBegin.tm_hour = 2;
       dstBegin.tm_min = 0;
@@ -182,7 +191,7 @@ void checkDST() {
       // DBG2("DST Begins: " + String(buf) + " local");
       time_t tdstBegin = mktime(&dstBegin) - stdOffset;
 #endif // USDST
-#ifdef EUDST
+#if (FDRS_DST_RULE == EUDST)
       dstBegin.tm_mday = 25;
       dstBegin.tm_hour = 1;
       dstBegin.tm_min = 0;
@@ -202,7 +211,7 @@ void checkDST() {
       }
     }
     else if(timeinfo.tm_mon == 9) {
-#ifdef EUDST
+#if (FDRS_DST_RULE == EUDST)
       struct tm dstEnd;
       dstEnd.tm_year = timeinfo.tm_year;
       dstEnd.tm_mon = 9;
@@ -222,15 +231,15 @@ void checkDST() {
       else if(tdstEnd != -1 && (time(NULL) - tdstEnd < 0) && isDST == false) { // STD -> DST
         dstFlag = 1;
       }
-#endif //EUDST
-#ifdef USDST
+#endif // EUDST
+#if (FDRS_DST_RULE == USDST)
       if(isDST == false) {
         dstFlag = 1;
       }
 #endif // USDST
     }
     else if(timeinfo.tm_mon == 10) {
-#ifdef USDST
+#if (FDRS_DST_RULE == USDST)
       struct tm dstEnd;
       dstEnd.tm_year = timeinfo.tm_year;
       dstEnd.tm_mon = 10;
@@ -250,8 +259,8 @@ void checkDST() {
       else if(tdstEnd != -1 && (time(NULL) - tdstEnd < 0) && isDST == false) { // STD -> DST
         dstFlag = 1;
       }
-#endif //USDST
-#ifdef EUDST
+#endif // USDST
+#if (FDRS_DST_RULE == EUDST)
       if(isDST == true) {
         dstFlag = 0;
       }


### PR DESCRIPTION
Add defines in fdrs_global.h for USDST and EUDST and related timekeeping defines.  Updated config files for those new defines.