### PR TITLE
Add more neighbors to ESP-NOW and LoRa 

### DIFF
--- a/src/fdrs_datatypes.h
+++ b/src/fdrs_datatypes.h
@@ -53,13 +53,17 @@ enum
 {
   event_clear,
   event_espnowg,
+  event_espnow0,
   event_espnow1,
   event_espnow2,
+  event_espnow3,
   event_serial,
   event_mqtt,
   event_lorag,
+  event_lora0,
   event_lora1,
   event_lora2,
+  event_lora3,
   event_internal
 };
 

--- a/src/fdrs_gateway.h
+++ b/src/fdrs_gateway.h
@@ -10,11 +10,17 @@
 #ifndef ESPNOWG_ACT
 #define ESPNOWG_ACT
 #endif
+#ifndef ESPNOW0_ACT
+#define ESPNOW0_ACT
+#endif
 #ifndef ESPNOW1_ACT
 #define ESPNOW1_ACT
 #endif
 #ifndef ESPNOW2_ACT
 #define ESPNOW2_ACT
+#endif
+#ifndef ESPNOW3_ACT
+#define ESPNOW3_ACT
 #endif
 #ifndef SERIAL_ACT
 #define SERIAL_ACT
@@ -239,11 +245,17 @@ void handleActions() {
     case event_espnowg:
       ESPNOWG_ACT
       break;
+    case event_espnow0:
+      ESPNOW0_ACT
+      break;
     case event_espnow1:
       ESPNOW1_ACT
       break;
     case event_espnow2:
       ESPNOW2_ACT
+      break;
+    case event_espnow3:
+      ESPNOW3_ACT
       break;
     case event_serial:
       SERIAL_ACT

--- a/src/fdrs_gateway_espnow.h
+++ b/src/fdrs_gateway_espnow.h
@@ -22,8 +22,16 @@ const uint8_t mac_prefix[] = {MAC_PREFIX};
 uint8_t selfAddress[] = {MAC_PREFIX, UNIT_MAC};
 uint8_t incMAC[6];
 
-uint8_t ESPNOW1[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_1};
-uint8_t ESPNOW2[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_2};
+// uint8_t ESPNOW1[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_1};
+// uint8_t ESPNOW2[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_2};
+// uint8_t ESPNOW3[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_3};
+// uint8_t ESPNOW4[] = {MAC_PREFIX, ESPNOW_NEIGHBOR_4};
+
+
+uint8_t ESPNOW_Nbr[4][6] = {{MAC_PREFIX, ESPNOW_NEIGHBOR_0},
+                          {MAC_PREFIX, ESPNOW_NEIGHBOR_1},
+                          {MAC_PREFIX, ESPNOW_NEIGHBOR_2},
+                          {MAC_PREFIX, ESPNOW_NEIGHBOR_3}};
 extern time_t now;
 // JL - pingFlagEspNow var probably to be removed
 bool pingFlagEspNow = false;
@@ -57,14 +65,24 @@ void OnDataRecv(const esp_now_recv_info *pkt_info, const uint8_t *incomingData, 
     memcpy(&theData, incomingData, sizeof(theData));
     DBG("Incoming ESP-NOW DataReading from 0x" + String(incMAC[5], HEX));
     ln = len / sizeof(DataReading);
-    if (memcmp(&incMAC, &ESPNOW1, 6) == 0)
+    if (memcmp(&incMAC, &ESPNOW_Nbr[0], 6) == 0)
+    {
+      newData = event_espnow0;
+      return;
+    }
+    if (memcmp(&incMAC, &ESPNOW_Nbr[1], 6) == 0)
     {
       newData = event_espnow1;
       return;
     }
-    if (memcmp(&incMAC, &ESPNOW2, 6) == 0)
+    if (memcmp(&incMAC, &ESPNOW_Nbr[2], 6) == 0)
     {
       newData = event_espnow2;
+      return;
+    }
+    if (memcmp(&incMAC, &ESPNOW_Nbr[3], 6) == 0)
+    {
+      newData = event_espnow3;
       return;
     }
     newData = event_espnowg;
@@ -236,81 +254,41 @@ void pingback_espnow()
   }
 }
 
-void sendESPNowNbr(uint8_t interface)
+void sendESPNowNbr(uint8_t neighbor)
 {
-  switch (interface)
+  DBG("Sending data to ESP-NOW Neighbor #" + String(neighbor));
+#if defined(ESP32)
+  esp_now_peer_info_t peerInfo;
+  peerInfo.ifidx = WIFI_IF_STA;
+  peerInfo.channel = 0;
+  peerInfo.encrypt = false;
+  memcpy(peerInfo.peer_addr, ESPNOW_Nbr[neighbor], 6);
+  if (esp_now_add_peer(&peerInfo) != ESP_OK)
   {
-    case 1:
-    { // These brackets are required!
-      DBG("Sending DR to ESP-NOW Neighbor #1");
-#if defined(ESP32)
-      esp_now_peer_info_t peerInfo;
-      peerInfo.ifidx = WIFI_IF_STA;
-      peerInfo.channel = 0;
-      peerInfo.encrypt = false;
-      memcpy(peerInfo.peer_addr, ESPNOW1, 6);
-      if (esp_now_add_peer(&peerInfo) != ESP_OK)
-      {
-        DBG("Failed to add peer");
-        return;
-      }
-#endif // ESP32
-      DataReading thePacket[ln];
-      int j = 0;
-
-      for (int i = 0; i < ln; i++)
-      {
-        if (j > espnow_size)
-        {
-          j = 0;
-          esp_now_send(ESPNOW1, (uint8_t *)&thePacket, sizeof(thePacket));
-        }
-        thePacket[j] = theData[i];
-        j++;
-      }
-      esp_now_send(ESPNOW1, (uint8_t *)&thePacket, j * sizeof(DataReading));
-      esp_now_del_peer(ESPNOW1);
-
-      break;
-    } // These brackets are required!
-    case 2:
-    {
-      DBG("Sending DR to ESP-NOW Neighbor #2");
-#if defined(ESP32)
-      esp_now_peer_info_t peerInfo;
-      peerInfo.ifidx = WIFI_IF_STA;
-      peerInfo.channel = 0;
-      peerInfo.encrypt = false;
-      memcpy(peerInfo.peer_addr, ESPNOW2, 6);
-      if (esp_now_add_peer(&peerInfo) != ESP_OK)
-      {
-        DBG("Failed to add peer");
-        return;
-      }
-#endif // ESP32
-      DataReading thePacket[ln];
-      int j = 0;
-      for (int i = 0; i < ln; i++)
-      {
-        if (j > espnow_size)
-        {
-          j = 0;
-          esp_now_send(ESPNOW2, (uint8_t *)&thePacket, sizeof(thePacket));
-        }
-        thePacket[j] = theData[i];
-        j++;
-      }
-      esp_now_send(ESPNOW2, (uint8_t *)&thePacket, j * sizeof(DataReading));
-      esp_now_del_peer(ESPNOW2);
-
-      break;
-    }
+    DBG("Failed to add peer");
+    return;
   }
+#endif // ESP32
+  DataReading thePacket[ln];
+  int j = 0;
+
+  for (int i = 0; i < ln; i++)
+  {
+    if (j > espnow_size)
+    {
+      j = 0;
+      esp_now_send(ESPNOW_Nbr[neighbor], (uint8_t *)&thePacket, sizeof(thePacket));
+    }
+    thePacket[j] = theData[i];
+    j++;
+  }
+  esp_now_send(ESPNOW_Nbr[neighbor], (uint8_t *)&thePacket, j * sizeof(DataReading));
+  esp_now_del_peer(ESPNOW_Nbr[neighbor]);
 }
 
 void sendESPNowPeers()
 {
-  DBG("Sending DR to ESP-NOW peers.");
+  DBG("Sending data to ESP-NOW peers.");
   DataReading thePacket[ln];
   int j = 0;
   for (int i = 0; i < ln; i++)
@@ -500,14 +478,13 @@ esp_err_t sendTimeESPNow() {
   esp_err_t result1 = ESP_OK, result2 = ESP_OK, result3 = ESP_OK;
   SystemPacket sys_packet = { .cmd = cmd_time, .param = now };
 
-  if((timeSource.tmAddress != (ESPNOW1[4] << 8 | ESPNOW1[5])) && ESPNOW1[5] != 0x00) {
-    DBG1("Sending time to ESP-NOW Peer 1");
-    result1 = sendESPNow(ESPNOW1, &sys_packet);
+for (uint8_t i = 0; i < 4; i++){
+  if((timeSource.tmAddress != (ESPNOW_Nbr[i][4] << 8 | ESPNOW_Nbr[i][5])) && ESPNOW_Nbr[i][5] != 0x00) {
+    DBG1("Sending time to ESP-NOW Neighbor #" + String(i));
+    result1 = sendESPNow(ESPNOW_Nbr[i], &sys_packet);
   }
-  if((timeSource.tmAddress != (ESPNOW2[4] << 8 | ESPNOW2[5])) && ESPNOW2[5] != 0x00) {
-    DBG1("Sending time to ESP-NOW Peer 2");
-    result2 = sendESPNow(ESPNOW2, &sys_packet);
-  }
+}
+
   DBG1("Sending time to ESP-NOW registered peers");
   result3 = sendESPNow(nullptr, &sys_packet);
 


### PR DESCRIPTION
Introducing our newest neighbors: `ESPNOW_NEIGHBOR_0` and `ESPNOW_NEIGHBOR_3`!

I have not actually tested this on devices, just ensured it compiled. Replace the existing ESP-NOW neighbor configs with the following. 
```
#define ESPNOW_NEIGHBOR_0  0x00  // Address of ESP-NOW Neighbor #0
#define ESPNOW_NEIGHBOR_1  0x00  // Address of ESP-NOW Neighbor #1
#define ESPNOW_NEIGHBOR_2  0x02  // Address of ESP-NOW Neighbor #2
#define ESPNOW_NEIGHBOR_3  0x00  // Address of ESP-NOW Neighbor #3
```
I'm excited to test it tomorrow!