### PR TITLE
fix: type conversion and remove deprecated ArduinoJson 7.2 function

### DIFF
--- a/src/fdrs_gateway_espnow.h
+++ b/src/fdrs_gateway_espnow.h
@@ -199,7 +199,7 @@ void add_espnow_peer()
     esp_now_send(incMAC, (uint8_t *)&sys_packet, sizeof(SystemPacket));
   }
 if(validTimeFlag){
-    SystemPacket sys_packet = { .cmd = cmd_time, .param = now };
+    SystemPacket sys_packet = { .cmd = cmd_time, .param = (uint32_t) now };
     esp_now_send(incMAC, (uint8_t *)&sys_packet, sizeof(SystemPacket));
   }
 }
@@ -498,7 +498,7 @@ void recvTimeEspNow(uint32_t t) {
 esp_err_t sendTimeESPNow() {
   
   esp_err_t result1 = ESP_OK, result2 = ESP_OK, result3 = ESP_OK;
-  SystemPacket sys_packet = { .cmd = cmd_time, .param = now };
+  SystemPacket sys_packet = { .cmd = cmd_time, .param = (uint32_t) now };
 
   if((timeSource.tmAddress != (ESPNOW1[4] << 8 | ESPNOW1[5])) && ESPNOW1[5] != 0x00) {
     DBG1("Sending time to ESP-NOW Peer 1");
@@ -523,7 +523,7 @@ esp_err_t sendTimeESPNow() {
 esp_err_t sendTimeESPNow(uint8_t *addr) {
   
   esp_err_t result = ESP_FAIL;
-  SystemPacket sys_packet = { .cmd = cmd_time, .param = now };
+  SystemPacket sys_packet = { .cmd = cmd_time, .param = (uint32_t) now };
   DBG1("Sending time to ESP-NOW address 0x" + String(addr[5],HEX));
   result = sendESPNow(addr, &sys_packet);
 

--- a/src/fdrs_gateway_serial.h
+++ b/src/fdrs_gateway_serial.h
@@ -161,7 +161,7 @@ void getSerial() {
   } else {
     int s = doc.size();
     JsonObject obj = doc[0].as<JsonObject>();
-    if(obj.containsKey("type")) { // DataReading
+    if(obj["type"].is<uint8_t>()) { // DataReading
     //UART_IF.println(s);
     for (int i = 0; i < s; i++) {
       theData[i].id = doc[i]["id"];
@@ -175,7 +175,7 @@ void getSerial() {
       serializeJson(doc, data);
       DBG1("DR data: " + data);
     }
-    else if(obj.containsKey("cmd")) { // SystemPacket
+    else if(obj["cmd"].is<uint32_t>()) { // SystemPacket
       cmd_t c = doc[0]["cmd"];
       uint32_t p = doc[0]["param"];
       if(c == cmd_time && p > MIN_TS) {


### PR DESCRIPTION
fix: deprecated ArduinoJson 7.2 function `containsKey()` -> `is<dataType>()`
fix: type conversion `time_t` -> `uint32_t`